### PR TITLE
feat: add clearCanvas function and UI button; reuse in modal save fun…

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,18 @@
         Save as Gate
       </button>
 
+      <button class="save-gate-btn" id="btn-clear-canvas" title="Clear canvas">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+          stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+          <path d="M10 11v6" />
+          <path d="M14 11v6" />
+          <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+        </svg>
+        Clear
+      </button>
+
       <button class="icon-btn" id="btn-settings" title="Settings" aria-label="Settings">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round">

--- a/ui/toolbar.js
+++ b/ui/toolbar.js
@@ -19,6 +19,15 @@ const modalCancel = document.getElementById("modal-cancel-btn");
 let _renderNodes = null;
 let _wires = null;
 
+function clearCanvas() {
+  if (state.intervalId !== null) {
+    clearInterval(state.intervalId);
+    state.intervalId = null;
+  }
+  _renderNodes.splice(0, _renderNodes.length);
+  _wires.splice(0, _wires.length);
+}
+
 function openSaveModal() {
   modalInput.value = "";
   modal.classList.add("open");
@@ -169,6 +178,7 @@ export function initToolbar(p, renderNodes, wires) {
     if (!name) { modalInput.focus(); return; }
     saveCompositeGate(name, _renderNodes, _wires);
     closeSaveModal();
+    clearCanvas();
     refreshCompositeSection();
   });
 
@@ -182,6 +192,9 @@ export function initToolbar(p, renderNodes, wires) {
   modal.addEventListener("click", e => {
     if (e.target === modal) closeSaveModal();
   });
+
+  // ─── Clear canvas ─────────────────────────────────────────────
+  document.getElementById("btn-clear-canvas").addEventListener("click", clearCanvas);
 
   // ─── Settings panel ────────────────────────────────────────────
   document.getElementById("btn-settings").addEventListener("click", openSettings);


### PR DESCRIPTION
This PR introduces a one-click **“Clear Canvas”** feature to improve usability when working with larger circuits. Users can now quickly reset the workspace without manually deleting each element.

---

### **Changes Implemented**

* Added a `clearCanvas` function to reset the entire canvas state
* Added a **“Clear”** button in the UI for easy access
* Integrated `clearCanvas` into `saveCompositeGate` to automatically reset the canvas after saving a composite gate

---

### **Behavior**

* On clicking the **Clear** button:

  * All gates, wires, and labels are removed
  * Canvas is reset to an empty state
* After saving a composite gate:

  * The canvas is automatically cleared using the same function