### PR TITLE
fix: change seeding logic to add all non-input gates when called from…

### DIFF
--- a/logic/evaluate.js
+++ b/logic/evaluate.js
@@ -1,10 +1,19 @@
-export function evaluateAll(renderNodes, wires) {
+export function evaluateAll(renderNodes, wires, seedAll = false) {
   let currentDelta = new Set();
   let nextDelta = new Set();
   const gateMap = {};
 
   for (const rn of renderNodes) {
     gateMap[rn.gate.id] = rn.gate;
+  }
+
+  // Seed all non-input gates when called from a composite gate
+  if (seedAll) {
+    for (const rn of renderNodes) {
+      if (rn.gate.type !== "input" && rn.gate.type !== "clock") {
+        currentDelta.add(rn.gate.id);
+      }
+    }
   }
 
   for (const wi of wires) {

--- a/logic/gates.js
+++ b/logic/gates.js
@@ -1,5 +1,5 @@
 import { Wire } from "./wire.js";
-import { evaluateAll } from "./evaluate.js";
+import { evaluateAll, settleCircuit } from "./evaluate.js";
 
 class Logic {
   static nextId = 1;
@@ -192,9 +192,8 @@ export class CompositeGate extends ConnectableGate {
     this.outputCount = this.internalOutputs.length;
     this.inputCount = this.internalInputs.length;
 
-    // Invalidate wire signals so the first evaluateAll detects changes
     for (const wi of this.circuitData.wires) {
-      wi.wire.signal = undefined;
+      wi.wire.signal = false;
     }
   }
 
@@ -210,7 +209,7 @@ export class CompositeGate extends ConnectableGate {
       this.internalInputs[i].setValue(resolvedInputs[i]);
     }
 
-    evaluateAll(this.circuitData.renderNodes, this.circuitData.wires);
+    evaluateAll(this.circuitData.renderNodes, this.circuitData.wires, true);
 
     // Assuming internalOutputs is array of output gates in the internal circuit
     for (let i = 0; i < this.internalOutputs.length; i++) {


### PR DESCRIPTION
… a composite gate in the first delta so feedback wires get evaluated but the next deltas remain change driven (closes #38)