### PR TITLE
Feat/39 custom waypoints

### DIFF
--- a/input/mouseHandlers.js
+++ b/input/mouseHandlers.js
@@ -194,7 +194,9 @@ export function registerMouseHandlers(p, renderNodes, wires) {
       if (state.changingWayPoint) {
         state.changingWayPoint.waypoint.x = p.mouseX;
         state.changingWayPoint.waypoint.y = p.mouseY;
-        state.changingWayPoint.otherWaypoint.x = state.changingWayPoint.waypoint.x;
+        if (state.changingWayPoint.otherWaypoint) {
+          state.changingWayPoint.otherWaypoint.x = state.changingWayPoint.waypoint.x;
+        }
       }
     }
   }
@@ -316,6 +318,7 @@ function findNearWaypoint(mx, my, p, wires) {
     const waypointCount = wires[i].waypoints.length;
     for (let j = 0; j < waypointCount; j++) {
       if (isNearWaypoint(mx, my, wires[i].waypoints[j], p)) {
+        if (wires[i].isCustomRouted) return { waypoint: wires[i].waypoints[j] };
         let otherWaypoint = null;
         if (waypointCount === 2) {
           otherWaypoint = wires[i].waypoints[j === 0 ? 1 : 0];

--- a/input/mouseHandlers.js
+++ b/input/mouseHandlers.js
@@ -2,7 +2,15 @@ import { state } from "../state.js";
 import { Input } from "../logic/gates.js";
 import { settleCircuit, evaluateAll } from "../logic/evaluate.js";
 import { CLOCK_TIMER, FREQUENCY } from "../constants.js";
-import { reComputeWayPoint, init_wire, getWirePorts } from "../render/wireGeometry.js";
+import { reComputeWayPoint, init_wire, getWirePorts, setCustomWaypoints } from "../render/wireGeometry.js";
+
+function cleanupGhostWire() {
+  if (state.ghostWireCleanup) {
+    state.ghostWireCleanup();
+    state.ghostWireCleanup = null;
+  }
+  state.ghostWire = null;
+}
 import { modeText } from "../ui/toolbar.js";
 import { setNodeSize } from "../render/RenderPoint.js";
 
@@ -29,13 +37,15 @@ export function registerMouseHandlers(p, renderNodes, wires) {
           let wire = wireConnection.toNode.gate.connect(state.drawingWire.fromNode.gate, inputIndex, outputIndex);
           setNodeSize(wireConnection.toNode);
           if (wire === null) return;
-          let wire_info = init_wire(renderNodes, wire);
+          let wire_info = init_wire(renderNodes, wire, state.ghostWire);
           wires.push(wire_info);
           adjustWaypoints(renderNodes, wires, state.drawingWire.fromNode.gate.id);
           state.drawingWire = null;
+          cleanupGhostWire();
           settleCircuit(renderNodes, wires);
         } else {
           state.drawingWire = null;
+          cleanupGhostWire();
         }
       } else {
         state.drawingWire = findNearOutputPort(p.mouseX, p.mouseY, p, renderNodes);
@@ -69,6 +79,10 @@ export function registerMouseHandlers(p, renderNodes, wires) {
               });
             }
           }
+        } else if (state.drawingWire && !state.changingWayPoint && !state.dragging) {
+          const { waypoints, cleanup } = setCustomWaypoints(p);
+          state.ghostWire = waypoints;
+          state.ghostWireCleanup = cleanup;
         }
       }
     } else if (state.mode === "run") {
@@ -216,7 +230,7 @@ function isNearPort(mouseX, mouseY, port, p) {
   return d < 15;
 }
 
-function isNearWaypoint(mx, my, waypoint, p) {
+export function isNearWaypoint(mx, my, waypoint, p) {
   const d = p.dist(mx, my, waypoint.x, waypoint.y);
   return d < 10;
 }

--- a/persistence.js
+++ b/persistence.js
@@ -31,13 +31,15 @@ function getGateData(node) {
 }
 
 function getWireData(w) {
-  return {
+  const data = {
     fromGateId: w.wire.from.id,
     toGateId: w.wire.to.id,
     toInputIndex: w.wire.toInputIndex,
     fromOutputIndex: w.wire.fromOutputIndex,
     waypoints: w.waypoints,
   };
+  if (w.isCustomRouted) data.isCustomRouted = true;
+  return data;
 }
 
 export function saveCompositeGate(name, renderNodes, wires) {
@@ -97,7 +99,9 @@ export function loadCompositeGate(name) {
     if (!fromNode || !toNode) return;
     const wire = toNode.gate.connect(fromNode.gate, w.toInputIndex, w.fromOutputIndex);
     if (wire === null) return;
-    wires.push({ wire, waypoints: w.waypoints });
+    const wire_info = { wire, waypoints: w.waypoints };
+    if (w.isCustomRouted) wire_info.isCustomRouted = true;
+    wires.push(wire_info);
   });
 
   return { renderNodes, wires };

--- a/render/draw.js
+++ b/render/draw.js
@@ -1,6 +1,7 @@
 import { FONT_SIZE, PORT_LABEL_SIZE } from "../constants.js";
 import { getActiveTheme } from "./theme.js";
 import { getWirePorts } from "./wireGeometry.js";
+import { state } from "../state.js";
 
 /**
  * Return "#ffffff" or "#1a1a2e" depending on which has better contrast
@@ -147,7 +148,16 @@ export function drawGhostWire(wire, p) {
   }
   p.stroke(theme.wires.ghost.hex);
   p.strokeWeight(3);
-  p.line(start.x, start.y, p.mouseX, p.mouseY);
+  if (state.ghostWire && state.ghostWire.length !== 0) {
+    p.line(start.x, start.y, state.ghostWire[0].x, state.ghostWire[0].y);
+    const waypoint_count = state.ghostWire.length;
+    for (let i = 0; i < waypoint_count - 1; i++) {
+      p.line(state.ghostWire[i].x, state.ghostWire[i].y, state.ghostWire[i + 1].x, state.ghostWire[i + 1].y);
+    }
+    p.line(state.ghostWire[waypoint_count - 1].x, state.ghostWire[waypoint_count - 1].y, p.mouseX, p.mouseY);
+  } else {
+    p.line(start.x, start.y, p.mouseX, p.mouseY);
+  }
   p.stroke(0);
   p.strokeWeight(1);
 }

--- a/render/draw.js
+++ b/render/draw.js
@@ -133,3 +133,21 @@ export function drawInputPorts(renderNodes, p) {
   p.stroke(0);
   p.strokeWeight(1);
 }
+
+export function drawGhostWire(wire, p) {
+  const theme = getActiveTheme();
+  const node = wire.fromNode;
+  let start;
+  if (node.gate.type === "composite") {
+    const index = wire.fromOutputIndex;
+    const outputCount = node.gate.outputCount;
+    start = node.getOutputPortByIndex(index, outputCount);
+  } else {
+    start = node.getOutputPort();
+  }
+  p.stroke(theme.wires.ghost.hex);
+  p.strokeWeight(3);
+  p.line(start.x, start.y, p.mouseX, p.mouseY);
+  p.stroke(0);
+  p.strokeWeight(1);
+}

--- a/render/wireGeometry.js
+++ b/render/wireGeometry.js
@@ -1,6 +1,15 @@
-export function init_wire(renderNodes, wire) {
-  let waypoints = computeWayPoints(renderNodes, wire);
-  return { wire: wire, waypoints: waypoints };
+import { isNearWaypoint } from "../input/mouseHandlers.js";
+
+export function init_wire(renderNodes, wire, custom_waypoints) {
+  let waypoints;
+  let isCustomRouted = false;
+  if (custom_waypoints && custom_waypoints.length !== 0) {
+    waypoints = custom_waypoints;
+    isCustomRouted = true;
+  } else {
+    waypoints = computeWayPoints(renderNodes, wire);
+  }
+  return { wire: wire, waypoints: waypoints, isCustomRouted: isCustomRouted };
 }
 
 export function getWirePorts(renderNodes, wire) {
@@ -48,6 +57,7 @@ export function computeWayPoints(renderNodes, wire) {
 }
 
 export function reComputeWayPoint(renderNodes, wire_info) {
+  if (wire_info.isCustomRouted) return;
   if (wire_info.wire.to.type === "composite") return;
   let newWayPoints = computeWayPoints(renderNodes, wire_info.wire);
   const waypointCount = newWayPoints.length;

--- a/render/wireGeometry.js
+++ b/render/wireGeometry.js
@@ -53,3 +53,26 @@ export function reComputeWayPoint(renderNodes, wire_info) {
   const waypointCount = newWayPoints.length;
   wire_info.waypoints[waypointCount - 1].y = newWayPoints[waypointCount - 1].y;
 }
+
+export function setCustomWaypoints(p) {
+  let waypoints = [];
+  function onKeyDown(e) {
+    if (e.key === " ") {
+      if (waypoints.length !== 0) {
+        const waypoint_count = waypoints.length;
+        if (!isNearWaypoint(p.mouseX, p.mouseY, waypoints[waypoint_count - 1], p)) {
+          waypoints.push({ x: p.mouseX, y: p.mouseY });
+        }
+      } else {
+        waypoints.push({ x: p.mouseX, y: p.mouseY });
+      }
+     }
+  }
+
+  function cleanup() {
+    document.removeEventListener("keydown", onKeyDown);
+  }
+
+  document.addEventListener("keydown", onKeyDown);
+  return { waypoints, cleanup };
+}

--- a/sketch.js
+++ b/sketch.js
@@ -1,5 +1,5 @@
 import { state } from "./state.js";
-import { drawGate, drawInputPorts, drawOutputPorts, drawWire } from "./render/draw.js";
+import { drawGate, drawGhostWire, drawInputPorts, drawOutputPorts, drawWire } from "./render/draw.js";
 import { registerMouseHandlers } from "./input/mouseHandlers.js";
 import { initToolbar } from "./ui/toolbar.js";
 import { getActiveTheme, applyTheme } from "./render/theme.js";
@@ -43,20 +43,7 @@ const sketch = (p) => {
       }
     }
     if (state.drawingWire) {
-      const node = state.drawingWire.fromNode;
-      let start;
-      if (node.gate.type === "composite") {
-        const index = state.drawingWire.fromOutputIndex;
-        const outputCount = node.gate.outputCount;
-        start = node.getOutputPortByIndex(index, outputCount);
-      } else {
-        start = state.drawingWire.fromNode.getOutputPort();
-      }
-      p.stroke(theme.wires.ghost.hex);
-      p.strokeWeight(3);
-      p.line(start.x, start.y, p.mouseX, p.mouseY);
-      p.stroke(0);
-      p.strokeWeight(1);
+      drawGhostWire(state.drawingWire, p);
     }
   }
 

--- a/state.js
+++ b/state.js
@@ -2,6 +2,8 @@ export const state = {
   mode: "edit",
   justPlacedFromToolbar: false,
   ghostNode: null,
+  ghostWire: null,
+  ghostWireCleanup: null,
   dragging: null,
   offsetX: 0,
   offsetY: 0,


### PR DESCRIPTION
## Title

Add custom waypoint support for wires + fix movement logic for manual waypoints

---

## Description

This PR introduces support for **user-defined (custom) waypoints** for wires in the logic simulator, allowing more flexible routing.

Users can now place waypoints manually (e.g., via spacebar), and wires will render as segmented paths through those points instead of relying solely on automatically computed routes.

While testing, a bug was identified in the waypoint movement logic where assumptions about fixed waypoint counts (2 or 4) caused incorrect behavior for manually defined waypoints. This has also been fixed in this PR.

---

## Features

* Add `setCustomWaypoints` function to allow users to place waypoints interactively
* Introduce `isCustomRouted` flag in wires to:

  * Disable automatic waypoint computation
  * Preserve user-defined routing
* Update wire rendering:

  * Draw segmented paths based on custom waypoints
  * Fallback to straight line if no custom waypoints exist
* Store custom routing information in composite gates

---

## Fixes

* Fix waypoint movement logic for manual waypoints
* Add `isCustomRouted` check in `findNearWaypoint` to differentiate behavior:

  * For **custom-routed wires**:

    * Return only the position of the waypoint being moved
    * Prevent unintended movement/alignment of other waypoints
  * For **automatically routed wires**:

    * Preserve existing logic based on computed waypoints (2 or 4)
    * Continue returning both the current and adjacent waypoint for alignment

---

## Refactor

* Extract ghost wire drawing logic into a separate function
* Add helper functions for ghost wire cleanup and initialization

---

## Issues

* Closes #39 (custom waypoint feature)
* Closes #44 (waypoint movement bug)