### PR TITLE
Refactor/55 circuit builder

### DIFF
--- a/input/mouseHandlers.js
+++ b/input/mouseHandlers.js
@@ -1,6 +1,5 @@
 import { state } from "../state.js";
 import { Input } from "../logic/gates.js";
-import { settleCircuit, evaluateAll } from "../logic/evaluate.js";
 import { CLOCK_TIMER, FREQUENCY } from "../constants.js";
 import { reComputeWayPoint, init_wire, getWirePorts, setCustomWaypoints } from "../render/wireGeometry.js";
 
@@ -14,7 +13,7 @@ function cleanupGhostWire() {
 
 import { setNodeSize } from "../render/RenderPoint.js";
 
-export function registerMouseHandlers(p, renderNodes, wires) {
+export function registerMouseHandlers(p, circuit, renderNodes, wires) {
   p.mousePressed = function () {
     if (state.labelEditing) return;
     if (state.justPlacedFromToolbar) {
@@ -34,15 +33,16 @@ export function registerMouseHandlers(p, renderNodes, wires) {
             console.error("Invalid index!");
             return;
           }
-          let wire = wireConnection.toNode.gate.connect(state.drawingWire.fromNode.gate, inputIndex, outputIndex);
-          setNodeSize(wireConnection.toNode);
+          const fromGate = state.drawingWire.fromNode.gate;
+          const toGate = wireConnection.toNode.gate;
+          let wire = circuit.connectGates(fromGate, toGate, outputIndex, inputIndex);
           if (wire === null) return;
+          setNodeSize(wireConnection.toNode);
           let wire_info = init_wire(renderNodes, wire, state.ghostWire);
           wires.push(wire_info);
           adjustWaypoints(renderNodes, wires, state.drawingWire.fromNode.gate.id);
           state.drawingWire = null;
           cleanupGhostWire();
-          settleCircuit(renderNodes, wires);
         } else {
           state.drawingWire = null;
           cleanupGhostWire();
@@ -88,7 +88,7 @@ export function registerMouseHandlers(p, renderNodes, wires) {
     } else if (state.mode === "run") {
       if (state.dragging && state.dragging.gate.type === "input") {
         state.dragging.gate.setValue(!state.dragging.gate.output);
-        evaluateAll(renderNodes, wires);
+        circuit.evaluate();
       } else if (state.dragging && state.dragging.gate.type === "clock") {
         if (state.dragging.intervalId != null) {
           clearInterval(state.dragging.intervalId);
@@ -99,7 +99,7 @@ export function registerMouseHandlers(p, renderNodes, wires) {
         const timeInterval = 1000 / (2 * FREQUENCY);
         state.dragging.intervalId = setInterval(() => {
           clockNode.gate.tick();
-          evaluateAll(renderNodes, wires);
+          circuit.evaluate();
         }, timeInterval);
 
         setTimeout(() => {
@@ -109,6 +109,7 @@ export function registerMouseHandlers(p, renderNodes, wires) {
       }
     } else if (state.mode === "placing") {
       state.mode = "edit";
+      circuit.registerGate(state.ghostNode.gate);
       renderNodes.push(state.ghostNode);
       state.ghostNode = null;
 
@@ -116,44 +117,24 @@ export function registerMouseHandlers(p, renderNodes, wires) {
       document.getElementById("btn-edit").classList.add("active");
     } else if (state.mode === "delete") {
       if (state.dragging) {
-        // Disconnect wire inputs from the gate's connected nodes
-        for (let i = 0; i < wires.length; i++) {
-          if (wires[i].wire.from.id === state.dragging.gate.id) {
-            wires[i].wire.to.inputs = wires[i].wire.to.inputs.filter(
-              input => input.from.id !== state.dragging.gate.id
-            );
-          }
-        }
+        const nodeId = renderNodes.indexOf(state.dragging);
+        const gateId = state.dragging.gate.id;
+
+        circuit.removeGate(gateId);
+        renderNodes.splice(nodeId, 1);
+
+        const toRemove = wires.filter(n => n.wire.from.id === state.dragging.gate.id || n.wire.to.id === state.dragging.gate.id);
+        toRemove.forEach(w => wires.splice(wires.indexOf(w), 1));
 
         for (let i = 0; i < renderNodes.length; i++) setNodeSize(renderNodes[i]);
         adjustWaypoints(renderNodes, wires, state.dragging.gate.id);
         // Mutate arrays in-place so sketch.js references stay valid
-        const toRemove = wires.filter(n => n.wire.from.id === state.dragging.gate.id || n.wire.to.id === state.dragging.gate.id);
-        toRemove.forEach(w => wires.splice(wires.indexOf(w), 1));
-        const nodeIdx = renderNodes.indexOf(state.dragging);
-        if (nodeIdx !== -1) renderNodes.splice(nodeIdx, 1);
         state.dragging = null;
-        settleCircuit(renderNodes, wires);
       } else {
         const wire_info = getWireAtPoint(p.mouseX, p.mouseY, renderNodes, wires);
         if (wire_info) {
+          circuit.removeWire(wire_info.wire);
           const toGate = wire_info.wire.to;
-          const removedIndex = wire_info.wire.toInputIndex;
-
-          if (toGate.type === "composite") {
-            // Composite gates have fixed-size input arrays; just clear the slot
-            toGate.inputs[removedIndex] = undefined;
-          } else {
-            // Basic gates & output: splice the input out by its index
-            toGate.inputs.splice(removedIndex, 1);
-
-            // Update toInputIndex on all remaining wires whose index shifted
-            for (const w of wires) {
-              if (w.wire.to.id === toGate.id && w.wire.toInputIndex > removedIndex) {
-                w.wire.toInputIndex--;
-              }
-            }
-          }
 
           // Resize the destination node to reflect the reduced input count
           const toRenderNode = renderNodes.find(n => n.gate.id === toGate.id);
@@ -167,7 +148,6 @@ export function registerMouseHandlers(p, renderNodes, wires) {
           }
 
           wires.splice(wires.indexOf(wire_info), 1);
-          settleCircuit(renderNodes, wires);
         }
       }
     }

--- a/logic/CircuitBuilder.js
+++ b/logic/CircuitBuilder.js
@@ -1,0 +1,161 @@
+import { evaluateAll, settleCircuit } from "./evaluate.js";
+import { CompositeGate, createBasicGate, createCompositeGate, Gate, Output } from "./gates.js";
+import { Wire } from "./wire.js";
+
+
+/**
+ * Builder class for constructing and managing a digital logic circuit. 
+ * Handles gates, wires, connections, evaluation, and structural updates. 
+ */
+export class CircuitBuilder {
+  constructor() {
+    /** @type {Map<number, Gate} Map of gateId -> gate instance */
+    this.gates = new Map();
+    /** @type {Array<Wire>} List of wire objects connecting gates */
+    this.wires = [];
+  }
+
+  /**
+   * Creates and adds a basic gate instance based on the given type. 
+   * 
+   * @param {string} type - The type of gate ("input", "output", "clock" or logic gate type)
+   * @returns {Input|Output|Clock|Gate} The instantiated gate object
+   */
+  addBasicGate(type) {
+    const gate = createBasicGate(type);
+    this.gates.set(gate.id, gate);
+    return gate;
+  }
+
+  /**
+   * Creates and adds a composite gate instance from the saved circuit data. 
+   * @param {string} name - The label/name of the composite gate
+   * @param {Object} circuitData - The circuit data used to construct the composite gate
+   * @returns {CompositeGate} The instantiated composite gate object
+   */
+  addCompositeGate(name, circuitData) {
+    const gate = createCompositeGate(name, circuitData);
+    this.gates.set(gate.id, gate);
+    return gate;
+  }
+
+  /**
+   * Removes a gate and all associated wires from the circuit. 
+   * Also updates the input indices of affected gates and settles the circuit. 
+   * 
+   * @param {number} gateId - ID of the gate to remove
+   */
+  removeGate(gateId) {
+    // Find wires connected to this gate
+    const affectedWires = this.wires.filter(
+      w => w.from.id === gateId || w.to.id === gateId
+    );
+
+    // Disconnect each affected wire
+    for (const wire of affectedWires) {
+      const toGate = wire.to;
+      const index = wire.toInputIndex;
+      this.disconnectWires(toGate, index);
+    }
+
+    // Remove all wires connected to this gate
+    this.wires = this.wires.filter(
+      w => w.from.id !== gateId && w.to.id !== gateId
+    );
+
+    this.gates.delete(gateId);
+    this.settle();
+  }
+
+
+  /**
+   * Connects two gates with a wire. 
+   * 
+   * @param {Gate} fromGate - Source gate
+   * @param {Gate} toGate - Destination gate
+   * @param {?number} fromOutputIndex - Output index of source gate (if multi-output)
+   * @param {?number} toInputIndex - Input index of destination gate
+   * @returns {Wire} The instantiated wire object
+   */
+  connectGates(fromGate, toGate, fromOutputIndex = null, toInputIndex = null) {
+    const wire = toGate.connect(fromGate, toInputIndex, fromOutputIndex);
+    this.wires.push(wire);
+    this.settle();
+    return wire;
+  }
+
+  /**
+   * Disconnects a wire from a gate's input. 
+   * 
+   * @param {Gate} toGate - Target gate whose input is being removed
+   * @param {number} removedIndex - Index of the input to remove
+   */
+  disconnectWires(toGate, removedIndex) {
+    if (toGate.type === "composite") {
+      // Composite gates have fixed-size input arrays; just clear the slot
+      toGate.inputs[removedIndex] = undefined;
+    } else {
+      // Basic gates & output: splice the input out by its index
+      toGate.inputs.splice(removedIndex, 1);
+
+      // Update toInputIndex on all remaining wires whose index shifted
+      for (const w of this.wires) {
+        if (w.to.id === toGate.id && w.toInputIndex > removedIndex) {
+          w.toInputIndex--;
+        }
+      }
+    }
+  }
+
+  /**
+   * Removes a specific wire from the circuit and updates the target gate. 
+   * 
+   * @param {Wire} wire - Wire object to remove
+   */
+  removeWire(wire) {
+    const toGate = wire.to;
+    const removedIndex = wire.toInputIndex;
+
+    this.disconnectWires(toGate, removedIndex);
+
+    this.wires = this.wires.filter(w => w !== wire);
+    this.settle();
+  }
+
+  /**
+   * Evaluates the circuit by Delta-cycle
+   */
+  evaluate() {
+    const renderNodes = [...this.gates.values()].map(g => ({ gate: g }));
+    const wireInfos = this.wires.map(w => ({ wire: w }));
+    evaluateAll(renderNodes, wireInfos);
+  }
+
+  /**
+   * Settles the circuit by repeatedly evaluating until it stabilizes. 
+   * Used after structural changes. 
+   */
+  settle() {
+    const renderNodes = [...this.gates.values()].map(g => ({ gate: g }));
+    const wireInfos = this.wires.map(w => ({ wire: w }));
+    settleCircuit(renderNodes, wireInfos);
+  }
+
+  /**
+   * Returns all gates in the circuit. 
+   * 
+   * @returns {Array<Gate>} List of gate instances
+   */
+  getGates() {
+    return [...this.gates.values()];
+  }
+
+  /**
+   * Returns all the wires in the circuit.  
+   * 
+   * @returns {Array<Wire>} List of wire instances
+   */
+  getWires() {
+    return this.wires;
+  }
+}

--- a/logic/CircuitBuilder.js
+++ b/logic/CircuitBuilder.js
@@ -84,12 +84,13 @@ export class CircuitBuilder {
    * @param {Gate} toGate - Destination gate
    * @param {?number} fromOutputIndex - Output index of source gate (if multi-output)
    * @param {?number} toInputIndex - Input index of destination gate
+   * @param {?Boolean} settle - Settles the circuit if true
    * @returns {Wire} The instantiated wire object
    */
-  connectGates(fromGate, toGate, fromOutputIndex = null, toInputIndex = null) {
+  connectGates(fromGate, toGate, fromOutputIndex = null, toInputIndex = null, settle = true) {
     const wire = toGate.connect(fromGate, toInputIndex, fromOutputIndex);
     this.wires.push(wire);
-    this.settle();
+    if (settle) this.settle();
     return wire;
   }
 

--- a/logic/CircuitBuilder.js
+++ b/logic/CircuitBuilder.js
@@ -40,6 +40,15 @@ export class CircuitBuilder {
   }
 
   /**
+   * Registers an existing gate instance into the circuit.
+   *
+   * @param {Gate} gate - Gate instance
+   */
+  registerGate(gate) {
+    this.gates.set(gate.id, gate);
+  }
+
+  /**
    * Removes a gate and all associated wires from the circuit. 
    * Also updates the input indices of affected gates and settles the circuit. 
    * 
@@ -157,5 +166,14 @@ export class CircuitBuilder {
    */
   getWires() {
     return this.wires;
+  }
+
+  /**
+   * Clears the entire circuit.
+   * Removes all gates and wires, resetting the builder to an empty state.
+   */
+  clear() {
+    this.gates.clear();
+    this.wires = [];
   }
 }

--- a/logic/CircuitBuilder.js
+++ b/logic/CircuitBuilder.js
@@ -135,9 +135,8 @@ export class CircuitBuilder {
    * Evaluates the circuit by Delta-cycle
    */
   evaluate() {
-    const renderNodes = [...this.gates.values()].map(g => ({ gate: g }));
-    const wireInfos = this.wires.map(w => ({ wire: w }));
-    evaluateAll(renderNodes, wireInfos);
+    const gates = [...this.gates.values()];
+    evaluateAll(gates, this.wires);
   }
 
   /**
@@ -145,9 +144,8 @@ export class CircuitBuilder {
    * Used after structural changes. 
    */
   settle() {
-    const renderNodes = [...this.gates.values()].map(g => ({ gate: g }));
-    const wireInfos = this.wires.map(w => ({ wire: w }));
-    settleCircuit(renderNodes, wireInfos);
+    const gates = [...this.gates.values()];
+    settleCircuit(gates, this.wires);
   }
 
   /**

--- a/logic/evaluate.js
+++ b/logic/evaluate.js
@@ -5,17 +5,17 @@
  * re-evaluating gates whose inputs have changed. It uses a delta-cycle
  * approach to efficiently handle evaluation.
  * 
- * @param {Array<RenderPoint>} renderNodes - List of render nodes containing gate instances
+ * @param {Array<Gate>} gates - List of gate instances
  * @param {Array<Wire>} wires - List of wire objects connecting gates
  * @param {boolean} [seedAll=false] - If true, forces evaluation of every gate in the first delta cycle
  */
-export function evaluateAll(renderNodes, wires, seedAll = false) {
+export function evaluateAll(gates, wires, seedAll = false) {
   let currentDelta = new Set();
   let nextDelta = new Set();
   const gateMap = {};
 
-  for (const rn of renderNodes) {
-    gateMap[rn.gate.id] = rn.gate;
+  for (const gate of gates) {
+    gateMap[gate.id] = gate;
   }
 
   /**
@@ -26,21 +26,21 @@ export function evaluateAll(renderNodes, wires, seedAll = false) {
    * change-driven evaluation
    */
   if (seedAll) {
-    for (const rn of renderNodes) {
-      if (rn.gate.type !== "input" && rn.gate.type !== "clock") {
-        currentDelta.add(rn.gate.id);
+    for (const gate of gates) {
+      if (gate.type !== "input" && gate.type !== "clock") {
+        currentDelta.add(gate.id);
       }
     }
   }
 
   // Seed inputs and clocks if their state is changed
-  for (const wi of wires) {
-    const from = wi.wire.from;
+  for (const wire of wires) {
+    const from = wire.from;
     if (from.type === "input" || from.type === "clock") {
       const newSignal = from.output;
-      if (wi.wire.signal !== newSignal) {
-        wi.wire.signal = newSignal;
-        currentDelta.add(wi.wire.to.id);
+      if (wire.signal !== newSignal) {
+        wire.signal = newSignal;
+        currentDelta.add(wire.to.id);
       }
     }
   }
@@ -66,16 +66,16 @@ export function evaluateAll(renderNodes, wires, seedAll = false) {
     if (Array.isArray(newOutput)) {
       if (!arraysEqual(newOutput, oldOutput)) {
         // TODO: Replace O(n) scan with fanout adjacency list
-        for (const wi of wires) {
-          if (wi.wire.from.id === gate.id) {
+        for (const wire of wires) {
+          if (wire.from.id === gate.id) {
             /**
              * NOTE:
              * Currently this propagates all outputs of composite gate
              * even if only one output port changes. 
              * Future optimization: track per-port changes
              */
-            wi.wire.signal = newOutput[wi.wire.fromOutputIndex];
-            const downstreamId = wi.wire.to.id;
+            wire.signal = newOutput[wire.fromOutputIndex];
+            const downstreamId = wire.to.id;
 
             nextDelta.add(downstreamId);
           }
@@ -83,11 +83,11 @@ export function evaluateAll(renderNodes, wires, seedAll = false) {
       }
     } else {
       if (newOutput !== oldOutput) {
-        for (const wi of wires) {
+        for (const wire of wires) {
           // TODO: Replace O(n) scan with fanout adjacency list
-          if (wi.wire.from.id === gate.id) {
-            wi.wire.signal = newOutput;
-            const downstreamId = wi.wire.to.id;
+          if (wire.from.id === gate.id) {
+            wire.signal = newOutput;
+            const downstreamId = wire.to.id;
 
             nextDelta.add(downstreamId);
           }
@@ -115,37 +115,36 @@ function arraysEqual(a, b) {
  * It is simpler but unefficient, and is used in scenarios where
  * full evaluation is required (e.g., stabilization)
  * 
- * @param {Array<RenderPoint>} renderNodes - List of render nodes containing gate instances
+ * @param {Array<Gate>} gates - List of gate instances
  * @param {Array<Wire>} wires - List of wire objects connecting gates
  */
-export function evaluateOnce(renderNodes, wires) {
+export function evaluateOnce(gates, wires) {
   // Update signals from input and clock sources
-  for (const wi of wires) {
-    const from = wi.wire.from;
+  for (const wire of wires) {
+    const from = wire.from;
     if (from.type === "input" || from.type === "clock") {
-      wi.wire.signal = from.output;
+      wire.signal = from.output;
     }
   }
 
   // Evaluate every non-input and non-clock gate regardless of change
-  for (const rn of renderNodes) {
-    const gate = rn.gate;
+  for (const gate of gates) {
     if (gate.type === "input" || gate.type === "clock") continue;
     gate.output = gate.evaluate();
     let signal;
-    for (const wi of wires) {
+    for (const wire of wires) {
       /**
        * NOTE:
        * This computes signal before verifying ownership (wire source). 
        * This is inefficient and can lead to undefined access for basic gates
        * 
        * TODO:
-       * Check `wi.wire.from.id === gate.id` before signal computation
+       * Check `wire.from.id === gate.id` before signal computation
        */
-      if (Array.isArray(gate.output)) signal = gate.output[wi.wire.fromOutputIndex];
+      if (Array.isArray(gate.output)) signal = gate.output[wire.fromOutputIndex];
       else signal = gate.output;
-      if (wi.wire.from.id === gate.id) {
-        wi.wire.signal = signal;
+      if (wire.from.id === gate.id) {
+        wire.signal = signal;
       }
     }
   }
@@ -158,18 +157,18 @@ export function evaluateOnce(renderNodes, wires) {
  * It is required because structural changes are not detected by change-driven
  * evaluation. 
  * 
- * @param {Array<RenderPoint>} renderNodes - List of render nodes containing gate instances
+ * @param {Array<Gate>} gates - List of gate instances
  * @param {Array<Wire>} wires - List of wire objects connecting gates
  */
-export function settleCircuit(renderNodes, wires) {
+export function settleCircuit(gates, wires) {
   let stable = false;
   // Prevent inifinite loops in oscillating circuits
   let iterations = 0;
 
   while (!stable && iterations < 100) {
-    const before = wires.map(w => w.wire.signal);
-    evaluateOnce(renderNodes, wires);
-    const after = wires.map(w => w.wire.signal);
+    const before = wires.map(w => w.signal);
+    evaluateOnce(gates, wires);
+    const after = wires.map(w => w.signal);
     stable = before.every((v, i) => v === after[i]);
     iterations++;
   }

--- a/logic/gates.js
+++ b/logic/gates.js
@@ -1,6 +1,9 @@
 import { Wire } from "./wire.js";
 import { evaluateAll } from "./evaluate.js";
 
+/**
+ * Base class for generating unique gate IDs. 
+ */
 class Logic {
   static nextId = 1;
 }
@@ -159,27 +162,16 @@ export class CompositeGate extends ConnectableGate {
   }
 
   parseCircuitData() {
-    let inputNodes = [];
-    let outputNodes = [];
-    this.circuitData.renderNodes.forEach(node => {
-      if (node.gate.type === "input") {
-        inputNodes.push(node);
-      } else if (node.gate.type === "output") {
-        outputNodes.push(node);
-      }
-    });
+    const gates = this.circuitData.builder.gates;
 
-    inputNodes.sort((a, b) => a.y - b.y);
-    outputNodes.sort((a, b) => a.y - b.y);
+    this.internalInputs = this.circuitData.inputOrder.map(id => gates.get(id));
+    this.internalOutputs = this.circuitData.outputOrder.map(id => gates.get(id));
 
-    this.internalInputs = inputNodes.map(node => node.gate);
-    this.internalOutputs = outputNodes.map(node => node.gate);
-
-    this.outputCount = this.internalOutputs.length;
     this.inputCount = this.internalInputs.length;
+    this.outputCount = this.internalOutputs.length;
 
-    for (const wi of this.circuitData.wires) {
-      wi.wire.signal = false;
+    for (const wire of this.circuitData.builder.wires) {
+      wire.signal = false;
     }
   }
 
@@ -190,17 +182,15 @@ export class CompositeGate extends ConnectableGate {
       }
     });
 
-    // Assuming internalInputs is array of input gates in the internal circuit
     for (let i = 0; i < this.internalInputs.length; i++) {
       this.internalInputs[i].setValue(resolvedInputs[i]);
     }
 
-    const gates = this.circuitData.renderNodes.map(node => node.gate);
-    const wires = this.circuitData.wires.map(w => w.wire);
+    const gates = this.circuitData.builder.getGates();
+    const wires = this.circuitData.builder.wires;
 
     evaluateAll(gates, wires, true);
 
-    // Assuming internalOutputs is array of output gates in the internal circuit
     for (let i = 0; i < this.internalOutputs.length; i++) {
       this.tempOutput[i] = this.internalOutputs[i].output;
     }
@@ -234,7 +224,8 @@ export function createBasicGate(type) {
  * @returns {CompositeGate} The instantiated composite gate object 
  */
 export function createCompositeGate(name, circuitData) {
-  const inputs = new Array(circuitData.renderNodes.filter(n => n.gate.type === "input").length);
+  const gates = circuitData.builder.getGates();
+  const inputs = new Array(gates.filter(gate => gate.type === "input").length);
   const gate = new CompositeGate(inputs, circuitData);
   gate.label = name;
   gate.parseCircuitData();

--- a/logic/gates.js
+++ b/logic/gates.js
@@ -195,7 +195,10 @@ export class CompositeGate extends ConnectableGate {
       this.internalInputs[i].setValue(resolvedInputs[i]);
     }
 
-    evaluateAll(this.circuitData.renderNodes, this.circuitData.wires, true);
+    const gates = this.circuitData.renderNodes.map(node => node.gate);
+    const wires = this.circuitData.wires.map(w => w.wire);
+
+    evaluateAll(gates, wires, true);
 
     // Assuming internalOutputs is array of output gates in the internal circuit
     for (let i = 0; i < this.internalOutputs.length; i++) {

--- a/persistence.js
+++ b/persistence.js
@@ -1,116 +1,214 @@
-import { createBasicNode, createCompositeNode } from "./render/RenderPoint.js";
+import { CircuitBuilder } from "./logic/CircuitBuilder.js";
+import { RenderPoint } from "./render/RenderPoint.js";
 
 const STORAGE_KEY = "compositeGates";
 
+/**
+ * Retrieves the composite gate store from localStorage. 
+ * 
+ * @returns {Object<string, { circuitData: Object, renderData: Object }}
+ * An object mapping gate names to their stored data. 
+ */
 function getStore() {
   const raw = localStorage.getItem(STORAGE_KEY);
   return raw ? JSON.parse(raw) : {};
 }
 
+/**
+ * Persists the composite gate store to localStorage. 
+ * 
+ * @param {Object<string, { circuitData: Object, renderData: Object }} store 
+ * The store object to save. 
+ */
 function setStore(store) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
 }
 
-function getGateData(node) {
-  const data = {
-    type: node.gate.type,
-    id: node.gate.id,
-    x: node.x,
-    y: node.y,
-  };
-  if (node.gate.type === "input" || node.gate.type === "clock") {
-    data.signal = node.gate.output;
+/**
+ * Extracts logical circuit data (gates, wires, IO ordering) from render nodes. 
+ * 
+ * @param {Array<RenderPoint>} renderNodes - Array of RenderPoint objects. 
+ * @param {Array<Object>} wire_infos - Array of wire object containing Wire instances. 
+ * @returns {{
+ *   gates: Array<Object>,
+ *   wires: Array<Object>,
+ *   inputOrder: Array<number>,
+ *   outputOrder: Array<number>
+ * }}
+ * Structured circuit data for reconstruction. 
+ */
+function getCircuitData(renderNodes, wire_infos) {
+  const gates = [];
+  const wires = [];
+  for (const node of renderNodes) {
+    const data = {
+      id: node.gate.id,
+      type: node.gate.type === "clock" ? "input" : node.gate.type,
+    };
+    if (node.gate.type === "input") {
+      data.signal = node.gate.output;
+    }
+    if (node.gate.label) {
+      data.label = node.gate.label;
+    }
+    gates.push(data);
   }
-  if (node.gate.label) {
-    data.label = node.gate.label;
+  
+  for (const w of wire_infos) {
+    const data = {
+      fromGateId: w.wire.from.id,
+      toGateId: w.wire.to.id,
+      toInputIndex: w.wire.toInputIndex,
+      fromOutputIndex: w.wire.fromOutputIndex,
+    }
+    wires.push(data);
   }
-  if (node.gate.type === "clock") {
-    data.label = "clk";
-  }
-  return data;
-}
 
-function getWireData(w) {
-  const data = {
-    fromGateId: w.wire.from.id,
-    toGateId: w.wire.to.id,
-    toInputIndex: w.wire.toInputIndex,
-    fromOutputIndex: w.wire.fromOutputIndex,
-    waypoints: w.waypoints,
-  };
-  if (w.isCustomRouted) data.isCustomRouted = true;
-  return data;
-}
-
-export function saveCompositeGate(name, renderNodes, wires) {
-  const gateData = [];
-  const wireData = [];
+  let inputNodes = [];
+  let outputNodes = [];
 
   renderNodes.forEach(node => {
-    const data = getGateData(node);
-    if (node.gate.type === "composite") {
-      data.compositeName = node.gate.label;
-    } else if (node.gate.type === "clock") {
-      data.type = "input";
-    }
-    gateData.push(data);
+    if (node.gate.type === "input" || node.gate.type === "clock") inputNodes.push(node);
+    else if (node.gate.type === "output") outputNodes.push(node);
   });
 
-  wires.forEach(w => {
-    wireData.push(getWireData(w));
-  });
+  inputNodes.sort((a, b) => a.y - b.y);
+  outputNodes.sort((a, b) => a.y - b.y);
+
+  const inputOrder = inputNodes.map(node => node.gate.id);
+  const outputOrder = outputNodes.map(node => node.gate.id);
+
+  return { gates, wires, inputOrder, outputOrder };
+}
+
+/**
+ * Extracts rendering data (positions and wire paths) from render nodes. 
+ * 
+ * @param {Array<RenderPoint>} renderNodes - Array of RenderPoint objects. 
+ * @param {Array<Object>} wire_infos - Array of wire objects containing Wire instances. 
+ * @returns {{
+ *   positions: Array<id: Number, x: number, y: number>,
+ *   wires: Array<Object>
+ * }}
+ * Structered render data for UI reconstruction. 
+ */
+function getRenderData(renderNodes, wire_infos) {
+  const positions = [];
+  const wires = [];
+
+  for (const node of renderNodes) {
+    const data = { "id": node.gate.id, "x": node.x, "y": node.y };
+    positions.push(data);
+  }
+
+  for (const w of wire_infos) {
+    const data = {
+      fromGateId: w.wire.from.id,
+      toGateId: w.wire.to.id,
+      waypoints: w.waypoints,
+    };
+    if (w.isCustomRouted) data.isCustomRouted = true;
+    wires.push(data);
+  }
+
+  return { positions, wires };
+}
+
+/**
+ * Saves a composite gate definition to localStorage. 
+ * 
+ * @param {string} name - Name of the composite gate. 
+ * @param {Array<RenderPoint>} renderNodes - Array of RenderPoint objects. 
+ * @param {Array<Object>} wires - Array of wire objects containing Wire instances. 
+ */
+export function saveCompositeGate(name, renderNodes, wires) {
+  const circuitData = getCircuitData(renderNodes, wires);
+  const renderData = getRenderData(renderNodes, wires);
 
   const store = getStore();
-  store[name] = { gateData, wireData };
+  store[name] = { circuitData, renderData };
   setStore(store);
 }
 
+/**
+ * Loads a composite gate definition from localStorage. 
+ * 
+ * @param {string} name - Name of the composite gate. 
+ * @returns {{ circuitData: Object, renderData: Object } | null}
+ * The stored gate and render data, or null if not found. 
+ */
 export function loadCompositeGate(name) {
   const store = getStore();
   if (!store[name]) return null;
-
-  const { gateData, wireData } = store[name];
-  const renderNodes = [];
-  const wires = [];
-
-  // Give internal nodes fresh IDs so they don't collide with canvas nodes
-  const idMap = {};
-  gateData.forEach(gate => {
-    let newNode;
-    if (gate.type === "composite") {
-      const circuitData = loadCompositeGate(gate.compositeName);
-      if (!circuitData) {
-        console.error(`Error: Missing nested composite gate '${gate.compositeName}'`);
-        return;
-      }
-      newNode = createCompositeNode(gate.compositeName, circuitData, gate.x, gate.y);
-    } else {
-      newNode = createBasicNode(gate.type, gate.x, gate.y);
-    }
-    idMap[gate.id] = newNode.gate.id;
-    if (gate.signal !== undefined) newNode.gate.output = gate.signal;
-    if (gate.label) newNode.gate.label = gate.label;
-    renderNodes.push(newNode);
-  });
-
-  wireData.forEach(w => {
-    const fromNode = renderNodes.find(n => n.gate.id === idMap[w.fromGateId]);
-    const toNode = renderNodes.find(n => n.gate.id === idMap[w.toGateId]);
-    if (!fromNode || !toNode) return;
-    const wire = toNode.gate.connect(fromNode.gate, w.toInputIndex, w.fromOutputIndex);
-    if (wire === null) return;
-    const wire_info = { wire, waypoints: w.waypoints };
-    if (w.isCustomRouted) wire_info.isCustomRouted = true;
-    wires.push(wire_info);
-  });
-
-  return { renderNodes, wires };
+  return store[name];
 }
 
+/**
+ * Reconstructs a circuit from serialized circuit data. 
+ * 
+ * @param {{
+ *   gates: Array<Gate>,
+ *   wires: Array<Wire>,
+ *   inputOrder: Array<number>,
+ *   outputOrder: Array<number>
+ * }} circuitData - Serialized circuit data. 
+ * @returns {{
+ *   builder: CircuitBuilder,
+ *   inputOrder: Array<number>,
+ *   outputOrder: Array<number>
+ * }}
+ * A builder instance with the reconstructed circuit and ordered IO mappings. 
+ * 
+ * @throws {Error} If a referenced nested composite gate is missing.
+ */
+export function buildCircuitFromData(circuitData) {
+  const builder = new CircuitBuilder();
+  const idMap = {};
+
+  for (const gateSpec of circuitData.gates) {
+    let gate;
+    if (gateSpec.type === "composite") {
+      const nestedCircuit = loadCompositeGate(gateSpec.label);
+      if (!nestedCircuit) throw new Error(`Missing nested gate: ${gateSpec.label}`);
+      const nestedBuilder = buildCircuitFromData(nestedCircuit.circuitData);
+      gate = builder.addCompositeGate(gateSpec.label, nestedBuilder);
+    } else {
+      gate = builder.addBasicGate(gateSpec.type);
+    }
+
+    idMap[gateSpec.id] = gate.id;
+    if (gateSpec.signal !== undefined) gate.output = gateSpec.signal;
+    if (gateSpec.label) gate.label = gateSpec.label;
+  }
+
+  for (const wireSpec of circuitData.wires) {
+    const fromGate = builder.gates.get(idMap[wireSpec.fromGateId]);
+    const toGate = builder.gates.get(idMap[wireSpec.toGateId]);
+    if (fromGate && toGate) {
+      builder.connectGates(fromGate, toGate, wireSpec.fromOutputIndex, wireSpec.toInputIndex, false);
+    }
+  }
+
+  const inputOrder = circuitData.inputOrder.map(id => idMap[id]);
+  const outputOrder = circuitData.outputOrder.map(id => idMap[id]);
+
+  return { builder, inputOrder, outputOrder };
+}
+
+/**
+ * Lists all saved composite gate names. 
+ * 
+ * @returns {Array<string>} Array of composite gate names. 
+ */
 export function listCompositeGates() {
   return Object.keys(getStore());
 }
 
+/**
+ * Deletes a composite gate from storage. 
+ * 
+ * @param {string} name - Name of the composite gate to delete. 
+ */
 export function deleteCompositeGate(name) {
   const store = getStore();
   delete store[name];

--- a/sketch.js
+++ b/sketch.js
@@ -3,6 +3,7 @@ import { drawGate, drawWaypoint, drawGhostWire, drawInputPorts, drawOutputPorts,
 import { registerMouseHandlers, isNearWaypoint } from "./input/mouseHandlers.js";
 import { initToolbar } from "./ui/toolbar.js";
 import { getActiveTheme, applyTheme } from "./render/theme.js";
+import { CircuitBuilder } from "./logic/CircuitBuilder.js";
 
 applyTheme(getActiveTheme());
 
@@ -14,12 +15,13 @@ const HEIGHT = canvasHost.clientHeight;
 
 let renderNodes = [];
 let wires = [];
+let circuit = new CircuitBuilder();
 
 const sketch = (p) => {
   p.setup = function () {
     const cnv = p.createCanvas(WIDTH, HEIGHT);
     cnv.parent(canvasHost);
-    initToolbar(p, renderNodes, wires);
+    initToolbar(p, circuit, renderNodes, wires);
   }
 
   p.draw = function () {
@@ -54,7 +56,7 @@ const sketch = (p) => {
     }
   }
 
-  registerMouseHandlers(p, renderNodes, wires);
+  registerMouseHandlers(p, circuit, renderNodes, wires);
 }
 
 new p5(sketch);

--- a/ui/toolbar.js
+++ b/ui/toolbar.js
@@ -19,11 +19,12 @@ const modalCancel = document.getElementById("modal-cancel-btn");
 let _renderNodes = null;
 let _wires = null;
 
-function clearCanvas() {
+function clearCanvas(circuit) {
   if (state.intervalId !== null) {
     clearInterval(state.intervalId);
     state.intervalId = null;
   }
+  circuit.clear();
   _renderNodes.splice(0, _renderNodes.length);
   _wires.splice(0, _wires.length);
 }
@@ -144,7 +145,7 @@ function refreshCompositeSection() {
 }
 
 // ─── Main init ──────────────────────────────────────────────────
-export function initToolbar(p, renderNodes, wires) {
+export function initToolbar(p, circuit, renderNodes, wires) {
   _renderNodes = renderNodes;
   _wires = wires;
 
@@ -179,7 +180,7 @@ export function initToolbar(p, renderNodes, wires) {
     if (!name) { modalInput.focus(); return; }
     saveCompositeGate(name, _renderNodes, _wires);
     closeSaveModal();
-    clearCanvas();
+    clearCanvas(circuit);
     refreshCompositeSection();
   });
 
@@ -195,7 +196,9 @@ export function initToolbar(p, renderNodes, wires) {
   });
 
   // ─── Clear canvas ─────────────────────────────────────────────
-  document.getElementById("btn-clear-canvas").addEventListener("click", clearCanvas);
+  document.getElementById("btn-clear-canvas").addEventListener("click", () => {
+    clearCanvas(circuit);
+  });
 
   // ─── Settings panel ────────────────────────────────────────────
   document.getElementById("btn-settings").addEventListener("click", openSettings);

--- a/ui/toolbar.js
+++ b/ui/toolbar.js
@@ -5,6 +5,7 @@ import {
   loadCompositeGate,
   listCompositeGates,
   deleteCompositeGate,
+  buildCircuitFromData,
 } from "../persistence.js";
 import { themes, getActiveThemeId, setActiveThemeId } from "../render/theme.js";
 
@@ -119,10 +120,11 @@ function refreshCompositeSection() {
     btn.title = `Place ${name}`;
     btn.textContent = name;
     btn.addEventListener("click", () => {
-      const circuitData = loadCompositeGate(name);
-      if (!circuitData) return;
+      const circuit = loadCompositeGate(name);
+      if (!circuit) return;
+      const compositeGate = buildCircuitFromData(circuit.circuitData);
       state.justPlacedFromToolbar = true;
-      spawnCompositeNode(name, circuitData, 0, 0);
+      spawnCompositeNode(name, compositeGate, 0, 0);
     });
 
     const del = document.createElement("button");


### PR DESCRIPTION
# Refactor: Introduce `CircuitBuilder` & Decouple Evaluation from Rendering

**Closes #53, Closes #57**

**Branch:** `feature/circuit-builder` → `main`
**Author:** Aditya Chaudhary
**Date range:** Apr 25 – Apr 27, 2026
**Stats:** 7 files changed, **+434** / **-178**

---

## Summary

This PR introduces a clean **separation of concerns** across the GateCraft codebase by:

1. **Creating a new `CircuitBuilder` class** (`logic/CircuitBuilder.js`) that encapsulates all core circuit manipulation logic — gate management, wire connections, disconnections, evaluation, and circuit settling.
2. **Decoupling the evaluation engine** (`logic/evaluate.js`) from the rendering layer, so `evaluateAll`, `evaluateOnce`, and `settleCircuit` now operate on raw `Array<Gate>` and `Array<Wire>` instead of `RenderPoint` and `{ wire }` wrapper objects.
3. **Refactoring persistence** (`persistence.js`) to separate circuit data from render data and reconstruct circuits via `CircuitBuilder` instead of directly instantiating render nodes.

The result is a layered architecture where:

- **`CircuitBuilder`** owns the circuit model (gates + wires + operations)
- **`RenderPoint` / render layer** owns visual representation only
- **`mouseHandlers`** acts as a thin controller, delegating logic to `CircuitBuilder`
- **`evaluate.js`** is a pure computation module with no UI dependencies

---

## Motivation

### Issue #53 — CircuitBuilder for Separation of Concerns

Previously, core circuit logic (creating gates, connecting/disconnecting wires, managing gate lifecycles) was scattered across `RenderPoint.js` and `mouseHandlers.js`. This mixed rendering, user input, and business logic, making the code harder to maintain, test, and extend.

### Issue #57 — Decouple Evaluation from Rendering

The evaluation functions (`evaluateAll`, `evaluateOnce`, `settleCircuit`) accepted `renderNodes` (array of `RenderPoint` wrappers) and `wireInfos` (array of `{ wire }` wrappers), even though they only used the inner `.gate` and `.wire` properties. This created unnecessary coupling between the evaluation engine and the rendering layer.

---

## Architecture

### Before

```
┌─────────────────┐     ┌──────────────────┐     ┌──────────────┐
│ mouseHandlers.js│────▶│  RenderPoint.js   │────▶│ evaluate.js  │
│  (input + logic)│     │ (render + logic)  │     │ (coupled to  │
│                 │     │                   │     │  renderNodes) │
└─────────────────┘     └──────────────────┘     └──────────────┘
```

### After

```
┌──────────────────┐        ┌─────────────────────┐
│ mouseHandlers.js │───────▶│  CircuitBuilder.js   │
│   (input only)   │        │   (core logic only)  │
└──────────────────┘        │                      │
                            │  gates: Map<id,Gate> │
┌──────────────────┐        │  wires: Wire[]       │
│   toolbar.js     │───────▶│                      │
│  (UI controls)   │        │  addBasicGate()      │
└──────────────────┘        │  addCompositeGate()   │
                            │  connectGates()      │
┌──────────────────┐        │  removeGate()        │
│  persistence.js  │───────▶│  removeWire()        │
│  (save/load)     │        │  evaluate()          │
└──────────────────┘        │  settle()            │
                            └──────────┬───────────┘
                                       │
                                       ▼
┌──────────────────┐        ┌──────────────────────┐
│ RenderPoint.js   │        │    evaluate.js        │
│ (rendering only) │        │ (pure computation)    │
└──────────────────┘        │                       │
                            │ evaluateAll(gates,    │
                            │             wires)    │
                            │ evaluateOnce(gates,   │
                            │              wires)   │
                            │ settleCircuit(gates,  │
                            │              wires)   │
                            └───────────────────────┘
```

---

## Detailed Changes

### `[NEW]` [CircuitBuilder.js](file:///home/aditya/code/javascript/GateCraft/logic/CircuitBuilder.js) — Core circuit management class

A new 178-line module introducing the `CircuitBuilder` class with the following API:

| Method | Description |
|---|---|
| `addBasicGate(type)` | Creates and registers a basic gate (input, output, clock, logic gates) |
| `addCompositeGate(name, circuitData)` | Creates and registers a composite gate from saved circuit data |
| `registerGate(gate)` | Registers an externally-created gate instance into the circuit |
| `removeGate(gateId)` | Removes a gate and all associated wires, updates indices, settles |
| `connectGates(from, to, outIdx, inIdx, settle?)` | Connects two gates with a wire, optionally settling the circuit |
| `disconnectWires(toGate, removedIndex)` | Handles input array cleanup for both basic and composite gates |
| `removeWire(wire)` | Removes a specific wire and updates the target gate |
| `evaluate()` | Delegates to `evaluateAll` using the builder's gate/wire data |
| `settle()` | Delegates to `settleCircuit` for stabilization after structural changes |
| `getGates()` / `getWires()` | Accessor methods returning current gates and wires |
| `clear()` | Resets the circuit to an empty state |

> [!IMPORTANT]
> The `connectGates` method includes a `settle` flag (default `true`) that controls whether the circuit is settled after a new connection. This is set to `false` during batch reconstruction (e.g., loading composite gates) to avoid redundant evaluations.

---

### `[MODIFY]` [evaluate.js](file:///home/aditya/code/javascript/GateCraft/logic/evaluate.js) — Decoupled from rendering layer

**Function signature changes:**

```diff
-evaluateAll(renderNodes, wires, seedAll = false)
+evaluateAll(gates, wires, seedAll = false)

-evaluateOnce(renderNodes, wires)
+evaluateOnce(gates, wires)

-settleCircuit(renderNodes, wires)
+settleCircuit(gates, wires)
```

**Key internal changes:**

- Replaced `rn.gate` accessor pattern with direct `gate` iteration
- Replaced `wi.wire` accessor pattern with direct `wire` iteration (e.g., `wire.from`, `wire.signal`, `wire.to.id`)
- No functional/algorithmic changes — this is a pure API surface refactor

---

### `[MODIFY]` [mouseHandlers.js](file:///home/aditya/code/javascript/GateCraft/input/mouseHandlers.js) — Delegated logic to CircuitBuilder

**Signature change:**

```diff
-registerMouseHandlers(p, renderNodes, wires)
+registerMouseHandlers(p, circuit, renderNodes, wires)
```

**Logic delegated to `CircuitBuilder`:**

| Action | Before | After |
|---|---|---|
| Wire connection | `toGate.connect(fromGate, ...)` + manual `settleCircuit()` | `circuit.connectGates(fromGate, toGate, ...)` |
| Input toggle | Manual `evaluateAll(renderNodes, wires)` | `circuit.evaluate()` |
| Clock toggle | Manual `evaluateAll(renderNodes, wires)` | `circuit.evaluate()` |
| Gate placement | Direct `renderNodes.push()` | `circuit.registerGate()` + `renderNodes.push()` |
| Gate deletion | Manual input splicing + wire filtering + `settleCircuit()` | `circuit.removeGate()` + render cleanup |
| Wire deletion | Manual `toGate.inputs.splice()` + index fixup + `settleCircuit()` | `circuit.removeWire()` + render cleanup |

**Removed imports:** `settleCircuit` and `evaluateAll` from `evaluate.js` — these are no longer needed in the input layer.

---

### `[MODIFY]` [persistence.js](file:///home/aditya/code/javascript/GateCraft/persistence.js) — Separated circuit data from render data

**Major structural changes:**

| Before | After |
|---|---|
| `saveCompositeGate` stored flat `gateData[]` + `wireData[]` mixing positions with logic | Stores separate `circuitData` (logic) and `renderData` (positions/waypoints) |
| `loadCompositeGate` reconstructed `renderNodes[]` + `wires[]` directly | Returns raw `{ circuitData, renderData }` from storage |
| Reconstruction used `createBasicNode` / `createCompositeNode` (render-level) | New `buildCircuitFromData()` uses `CircuitBuilder` for pure logic reconstruction |

**New functions:**

- **`getCircuitData(renderNodes, wireInfos)`** — Extracts gate types, signals, labels, wire connections, and deterministic input/output ordering (sorted by Y-position)
- **`getRenderData(renderNodes, wireInfos)`** — Extracts positions, waypoints, and custom routing flags
- **`buildCircuitFromData(circuitData)`** — Recursively reconstructs a circuit using `CircuitBuilder`, returning `{ builder, inputOrder, outputOrder }`

> [!NOTE]
> The `inputOrder` and `outputOrder` arrays are stored during serialization (sorted by Y-position) and mapped to fresh IDs during reconstruction. This ensures deterministic port ordering for composite gates regardless of creation order.

**Storage format change:**

```diff
-store[name] = { gateData, wireData }
+store[name] = { circuitData, renderData }
```

> [!WARNING]
> This is a **breaking change** to the localStorage schema. Previously saved composite gates using the old `{ gateData, wireData }` format will not load correctly. Users may need to clear their localStorage or re-create saved composite gates.

---

### `[MODIFY]` [gates.js](file:///home/aditya/code/javascript/GateCraft/logic/gates.js) — Updated `CompositeGate` internals

**`parseCircuitData()` refactored:**

```diff
-// Scanned renderNodes for input/output gates, sorted by Y-position
-this.internalInputs = inputNodes.map(node => node.gate);
-this.internalOutputs = outputNodes.map(node => node.gate);
+// Uses pre-computed inputOrder/outputOrder from circuitData
+this.internalInputs = this.circuitData.inputOrder.map(id => gates.get(id));
+this.internalOutputs = this.circuitData.outputOrder.map(id => gates.get(id));
```

**`evaluate()` refactored:**

```diff
-evaluateAll(this.circuitData.renderNodes, this.circuitData.wires, true);
+const gates = this.circuitData.builder.getGates();
+const wires = this.circuitData.builder.wires;
+evaluateAll(gates, wires, true);
```

**`createCompositeGate()` updated:**

```diff
-const inputs = new Array(circuitData.renderNodes.filter(n => n.gate.type === "input").length);
+const gates = circuitData.builder.getGates();
+const inputs = new Array(gates.filter(gate => gate.type === "input").length);
```

---

### `[MODIFY]` [sketch.js](file:///home/aditya/code/javascript/GateCraft/sketch.js) — Wiring up CircuitBuilder

```diff
+import { CircuitBuilder } from "./logic/CircuitBuilder.js";

 let renderNodes = [];
 let wires = [];
+let circuit = new CircuitBuilder();

-initToolbar(p, renderNodes, wires);
+initToolbar(p, circuit, renderNodes, wires);

-registerMouseHandlers(p, renderNodes, wires);
+registerMouseHandlers(p, circuit, renderNodes, wires);
```

---

### `[MODIFY]` [toolbar.js](file:///home/aditya/code/javascript/GateCraft/ui/toolbar.js) — Updated to use CircuitBuilder

```diff
-export function initToolbar(p, renderNodes, wires)
+export function initToolbar(p, circuit, renderNodes, wires)

-function clearCanvas()
+function clearCanvas(circuit)
```

- `clearCanvas` now calls `circuit.clear()` before splicing render arrays
- Composite gate placement uses `buildCircuitFromData()` + `circuit.addCompositeGate()` pipeline
- Clear canvas button uses lambda to pass `circuit` reference

---

## Commit History (11 commits, chronological)

| # | Hash | Type | Message |
|---|---|---|---|
| 1 | `a250120` | feat | Add `CircuitBuilder` class which encapsulates all core logic |
| 2 | `256c920` | feat | Add `registerGate` and `clear` method |
| 3 | `8ba5586` | feat | Update `initToolbar` and `clearCanvas` to use CircuitBuilder |
| 4 | `36b4324` | feat | Update `registerMouseHandlers` to use CircuitBuilder methods |
| 5 | `35b5495` | feat | Add CircuitBuilder instantiation in `sketch.js`, pass to handlers |
| 6 | `4139de7` | refactor | Update evaluation functions to operate on `Array<Gate>`, `Array<Wire>` |
| 7 | `a0c8b75` | refactor | Update `evaluateAll` call sites to work with new API (closes #57) |
| 8 | `6955c61` | feat | Add `settle` flag to `connectGates` method |
| 9 | `9363871` | refactor | Separate circuit and render data, add builder-based reconstruction |
| 10 | `73c6b58` | refactor | Use builder-based circuit data for composite gates |
| 11 | `970d0ff` | refactor | Use builder-based composite gate creation |

---

## Testing

### Manual Verification

- [ ] Place basic gates (AND, OR, NOT, XOR, NAND, NOR, XNOR) — verify rendering and connectivity
- [ ] Place Input/Output/Clock gates — verify toggle and clock behavior
- [ ] Connect gates with wires — verify signal propagation
- [ ] Delete gates — verify cleanup of associated wires and circuit re-settling
- [ ] Delete wires — verify input index fixup and circuit re-settling
- [ ] Save a composite gate — verify serialization to `{ circuitData, renderData }`
- [ ] Load and place a composite gate — verify correct reconstruction and evaluation
- [ ] Test nested composite gates — verify recursive `buildCircuitFromData` works
- [ ] Clear canvas — verify both `CircuitBuilder` and render arrays are reset
- [ ] Test sequential circuits (SR latch, D latch, T flip-flop) — verify evaluation stability

### Regression Concerns

- Wire deletion index fixup logic has moved from `mouseHandlers.js` to `CircuitBuilder.disconnectWires()` — verify it behaves identically for both basic and composite gate targets
- Composite gate port ordering now uses stored `inputOrder`/`outputOrder` instead of runtime Y-sort — verify ordering matches for existing saved gates

---

## Breaking Changes

> [!CAUTION]
> **localStorage schema change:** The composite gate storage format changed from `{ gateData, wireData }` to `{ circuitData, renderData }`. Any composite gates saved before this PR will fail to load. Users should clear localStorage (`localStorage.removeItem("composite_gates")` or equivalent) and re-save their composite gates.
