### PR TITLE
fix: skip evaluation of unconnected gates in evaluateOnce

### DIFF
--- a/logic/evaluate.js
+++ b/logic/evaluate.js
@@ -135,6 +135,7 @@ export function evaluateOnce(gates, wires) {
   // Evaluate every non-input and non-clock gate regardless of change
   for (const gate of gates) {
     if (gate.type === "input" || gate.type === "clock") continue;
+    if (!gate.hasAllInputsConnected()) continue;
     const result = gate.evaluate();
     if (!result.ok) {
       console.error(result.error);

--- a/logic/gates.js
+++ b/logic/gates.js
@@ -36,6 +36,19 @@ export class Clock extends Input {
   }
 }
 
+/**
+ * Checks whether an array is sparse (i.e., contains "holes" / missing indices).
+ *
+ * @param {Array<any>} array - The array to check for sparsity.
+ * @returns {boolean} Returns `true` if the array is sparse otherwise `false`.
+ */
+function isSparse(array) {
+  for (let i = 0; i < array.length; i++) {
+    if (!(i in array)) return true;
+  }
+  return false;
+}
+
 class ConnectableGate {
   connect(fromGate, toInputIndex = null, fromOutputIndex = null) {
     if (toInputIndex === null) {
@@ -46,6 +59,29 @@ class ConnectableGate {
     const wire = new Wire(fromGate, this, toInputIndex, fromOutputIndex);
     this.inputs[toInputIndex] = wire;
     return { ok: true, wire };
+  }
+
+  /**
+   * Determines whether all input connections for the gate are properly connected.
+   *
+   * This method accounts for two types of gate input representations:
+   *
+   * - **Basic gates**:
+   *   - The `inputs` array is dynamic (grows as connections are added).
+   *   - If no inputs are connected, the array is empty (`length === 0`).
+   *
+   * - **Composite gates**:
+   *   - The `inputs` array has a fixed length.
+   *   - Unconnected inputs are represented as "holes" (sparse indices).
+   *
+   * A gate is considered "fully connected" if:
+   * - The `inputs` array is not sparse (i.e., no missing indices / holes), AND
+   * - The `inputs` array contains at least one element
+   *
+   * @returns {boolean} Returns `true` if all inputs are connected, otherwise `false`.
+   */
+  hasAllInputsConnected() {
+    return !isSparse(this.inputs) && this.inputs.length > 0;
   }
 }
 


### PR DESCRIPTION
Prevent evaluateOnce from evaluating gates that do not have all inputs connected. This avoids misleading error logs during incremental circuit construction (e.g., when gates are placed first and wired step-by-step).

- Added ConnectableGate.hasAllInputsConnected() to centralize input validation
- Introduced isSparse() utility to detect unconnected inputs in fixed-size arrays
- Updated evaluateOnce to skip gates with incomplete inputs

This ensures evaluateOnce behaves as a stabilization pass rather than triggering premature evaluation errors, while leaving evaluateAll behavior unchanged.