### PR TITLE
Fix/typos

### DIFF
--- a/logic/evaluate.c
+++ b/logic/evaluate.c
@@ -51,7 +51,7 @@ void init(
 }
 
 
-uint8_t evalauteGate(uint8_t type, uint8_t *inputs, uint8_t inputCount) {
+uint8_t evaluateGate(uint8_t type, uint8_t *inputs, uint8_t inputCount) {
     uint8_t output;
 
     switch (type)
@@ -173,7 +173,7 @@ int evaluateFlat() {
             }
 
             const uint8_t oldOutput = allOutputs[outputOffset[gateIndex]];
-            const uint8_t newOutput = evalauteGate(gateTypes[gateIndex], inputSignals, count);
+            const uint8_t newOutput = evaluateGate(gateTypes[gateIndex], inputSignals, count);
 
             allOutputs[outputOffset[gateIndex]] = newOutput;
 

--- a/logic/evaluate.js
+++ b/logic/evaluate.js
@@ -138,7 +138,6 @@ export function evaluateOnce(circuit) {
     }
     const newOutput = result.output;
     gate.output = newOutput;
-    let signal;
     for (const wire of wires) {
       if (wire.from.id !== gate.id) continue;
 

--- a/logic/evaluate.js
+++ b/logic/evaluate.js
@@ -115,9 +115,9 @@ function arraysEqual(a, b) {
  * 
  * @param {CircuitBuilder} circuit - The circuit instance containing the gates, wires, and fanout map 
  */
-export function evaluateOnce(ciruict) {
-  const wires = ciruict.wires;
-  const gates = ciruict.getGates();
+export function evaluateOnce(circuit) {
+  const wires = circuit.wires;
+  const gates = circuit.getGates();
   let changed = false;
   // Update signals from input and clock sources
   for (const wire of wires) {


### PR DESCRIPTION
# Fix typos and remove unused variable

## Summary

This PR fixes a few minor code quality issues:

* Renamed `evalauteGate` to `evaluateGate` in `evaluate.c`
* Corrected typo `ciruict` → `circuit` in `evaluate.js`
* Removed an unused variable

## Changes

### `evaluate.c`

* Fixed function name typo:

  * `evalauteGate` → `evaluateGate`

### `evaluate.js`

* Fixed variable typo:

  * `ciruict` → `circuit`

### Cleanup

* Removed an unused variable to reduce clutter and avoid linter warnings.

## Impact

These changes are non-functional and improve readability, consistency, and maintainability of the codebase.
