### PR TITLE
Refactor/naming convention

### DIFF
--- a/input/mouseHandlers.js
+++ b/input/mouseHandlers.js
@@ -1,7 +1,7 @@
 import { state } from "../state.js";
 import { Input } from "../logic/gates.js";
 import { CLOCK_TIMER, FREQUENCY } from "../constants.js";
-import { reComputeWayPoint, init_wire, getWirePorts, setCustomWaypoints } from "../render/wireGeometry.js";
+import { reComputeWayPoint, initWire, getWirePorts, setCustomWaypoints } from "../render/wireGeometry.js";
 
 function cleanupGhostWire() {
   if (state.ghostWireCleanup) {
@@ -40,8 +40,8 @@ export function registerMouseHandlers(p, circuit, renderNodes, wires) {
           let wire = circuit.connectGates(fromGate, toGate, outputIndex, inputIndex);
           if (wire === null) return;
           setNodeSize(wireConnection.toNode);
-          let wire_info = init_wire(renderNodes, wire, state.ghostWire, nodeMap);
-          wires.push(wire_info);
+          let wireInfo = initWire(renderNodes, wire, state.ghostWire, nodeMap);
+          wires.push(wireInfo);
           adjustWaypoints(renderNodes, wires, state.drawingWire.fromNode.gate.id);
           state.drawingWire = null;
           cleanupGhostWire();
@@ -136,10 +136,10 @@ export function registerMouseHandlers(p, circuit, renderNodes, wires) {
 
         reBuildNodeMap(renderNodes, nodeMap);
       } else {
-        const wire_info = getWireAtPoint(p.mouseX, p.mouseY, renderNodes, wires, nodeMap);
-        if (wire_info) {
-          circuit.removeWire(wire_info.wire);
-          const toGate = wire_info.wire.to;
+        const wireInfo = getWireAtPoint(p.mouseX, p.mouseY, renderNodes, wires, nodeMap);
+        if (wireInfo) {
+          circuit.removeWire(wireInfo.wire);
+          const toGate = wireInfo.wire.to;
 
           // Resize the destination node to reflect the reduced input count
           const toRenderNode = renderNodes.find(n => n.gate.id === toGate.id);
@@ -152,7 +152,7 @@ export function registerMouseHandlers(p, circuit, renderNodes, wires) {
             }
           }
 
-          wires.splice(wires.indexOf(wire_info), 1);
+          wires.splice(wires.indexOf(wireInfo), 1);
         }
       }
     }
@@ -279,18 +279,18 @@ function isOnWireSegment(A, B, O, threshold) {
 }
 
 function getWireAtPoint(mx, my, renderNodes, wires, nodeMap) {
-  for (const wire_info of wires) {
-    const port = getWirePorts(renderNodes, wire_info.wire, nodeMap);
+  for (const wireInfo of wires) {
+    const port = getWirePorts(renderNodes, wireInfo.wire, nodeMap);
     const points = [];
     points.push(port.start);
-    for (const waypoint of wire_info.waypoints) {
+    for (const waypoint of wireInfo.waypoints) {
       points.push(waypoint);
     }
     points.push(port.end);
 
     for (let i = 0; i < points.length - 1; i++) {
       if (isOnWireSegment(points[i], points[i + 1], { x: mx, y: my }, 15)) {
-        return wire_info;
+        return wireInfo;
       }
     }
   }

--- a/input/mouseHandlers.js
+++ b/input/mouseHandlers.js
@@ -1,7 +1,7 @@
 import { state } from "../state.js";
 import { Input } from "../logic/gates.js";
 import { CLOCK_TIMER, FREQUENCY } from "../constants.js";
-import { reComputeWayPoint, initWire, getWirePorts, setCustomWaypoints } from "../render/wireGeometry.js";
+import { recomputeWayPoint, initWire, getWirePorts, setCustomWaypoints } from "../render/wireGeometry.js";
 
 function cleanupGhostWire() {
   if (state.ghostWireCleanup) {
@@ -11,7 +11,7 @@ function cleanupGhostWire() {
   state.ghostWire = null;
 }
 
-import { reBuildNodeMap, setNodeSize } from "../render/RenderPoint.js";
+import { rebuildNodeMap, setNodeSize } from "../render/RenderPoint.js";
 
 export const nodeMap = new Map();
 
@@ -113,7 +113,7 @@ export function registerMouseHandlers(p, circuit, renderNodes, wires) {
       state.mode = "edit";
       circuit.registerGate(state.ghostNode.gate);
       renderNodes.push(state.ghostNode);
-      reBuildNodeMap(renderNodes, nodeMap);
+      rebuildNodeMap(renderNodes, nodeMap);
       state.ghostNode = null;
 
       document.querySelectorAll(".mode-btn").forEach(b => b.classList.remove("active"));
@@ -134,7 +134,7 @@ export function registerMouseHandlers(p, circuit, renderNodes, wires) {
         // Mutate arrays in-place so sketch.js references stay valid
         state.dragging = null;
 
-        reBuildNodeMap(renderNodes, nodeMap);
+        rebuildNodeMap(renderNodes, nodeMap);
       } else {
         const wireInfo = getWireAtPoint(p.mouseX, p.mouseY, renderNodes, wires, nodeMap);
         if (wireInfo) {
@@ -148,7 +148,7 @@ export function registerMouseHandlers(p, circuit, renderNodes, wires) {
           // Re-compute waypoints for all remaining wires going into this gate
           for (const w of wires) {
             if (w.wire.to.id === toGate.id) {
-              reComputeWayPoint(renderNodes, w, nodeMap);
+              recomputeWayPoint(renderNodes, w, nodeMap);
             }
           }
 
@@ -329,7 +329,7 @@ function adjustWaypoints(renderNodes, wires, fromGateId) {
       // Only re-compute waypoints for gates which are connected to toGate
       for (let j = 0; j < wires.length; j++) {
         if (wires[j].wire.to.id === toGate) {
-          reComputeWayPoint(renderNodes, wires[j], nodeMap);
+          recomputeWayPoint(renderNodes, wires[j], nodeMap);
         }
       }
       break;

--- a/persistence.js
+++ b/persistence.js
@@ -28,7 +28,7 @@ function setStore(store) {
  * Extracts logical circuit data (gates, wires, IO ordering) from render nodes. 
  * 
  * @param {Array<RenderPoint>} renderNodes - Array of RenderPoint objects. 
- * @param {Array<Object>} wire_infos - Array of wire object containing Wire instances. 
+ * @param {Array<Object>} wireInfos - Array of wire object containing Wire instances. 
  * @returns {{
  *   gates: Array<Object>,
  *   wires: Array<Object>,
@@ -37,7 +37,7 @@ function setStore(store) {
  * }}
  * Structured circuit data for reconstruction. 
  */
-function getCircuitData(renderNodes, wire_infos) {
+function getCircuitData(renderNodes, wireInfos) {
   const gates = [];
   const wires = [];
   for (const node of renderNodes) {
@@ -54,7 +54,7 @@ function getCircuitData(renderNodes, wire_infos) {
     gates.push(data);
   }
   
-  for (const w of wire_infos) {
+  for (const w of wireInfos) {
     const data = {
       fromGateId: w.wire.from.id,
       toGateId: w.wire.to.id,
@@ -85,14 +85,14 @@ function getCircuitData(renderNodes, wire_infos) {
  * Extracts rendering data (positions and wire paths) from render nodes. 
  * 
  * @param {Array<RenderPoint>} renderNodes - Array of RenderPoint objects. 
- * @param {Array<Object>} wire_infos - Array of wire objects containing Wire instances. 
+ * @param {Array<Object>} wireInfos - Array of wire objects containing Wire instances. 
  * @returns {{
  *   positions: Array<id: Number, x: number, y: number>,
  *   wires: Array<Object>
  * }}
  * Structered render data for UI reconstruction. 
  */
-function getRenderData(renderNodes, wire_infos) {
+function getRenderData(renderNodes, wireInfos) {
   const positions = [];
   const wires = [];
 
@@ -101,7 +101,7 @@ function getRenderData(renderNodes, wire_infos) {
     positions.push(data);
   }
 
-  for (const w of wire_infos) {
+  for (const w of wireInfos) {
     const data = {
       fromGateId: w.wire.from.id,
       toGateId: w.wire.to.id,

--- a/render/RenderPoint.js
+++ b/render/RenderPoint.js
@@ -174,7 +174,7 @@ export function setNodeSize(node) {
   node.height = height;
 }
 
-export function reBuildNodeMap(renderNodes, nodeMap) {
+export function rebuildNodeMap(renderNodes, nodeMap) {
   nodeMap.clear();
 
   for (const node of renderNodes) {

--- a/render/draw.js
+++ b/render/draw.js
@@ -47,20 +47,20 @@ export function drawGate(renderNode, p) {
   p.strokeWeight(1);
 }
 
-export function drawWire(renderNodes, wire_info, nodeMap, p) {
+export function drawWire(renderNodes, wireInfo, nodeMap, p) {
   const theme = getActiveTheme();
-  const ports = getWirePorts(renderNodes, wire_info.wire, nodeMap);
+  const ports = getWirePorts(renderNodes, wireInfo.wire, nodeMap);
   p.strokeWeight(3);
 
-  let color = wire_info.wire.signal ? theme.wires.high.hex : theme.wires.low.hex;
+  let color = wireInfo.wire.signal ? theme.wires.high.hex : theme.wires.low.hex;
   p.stroke(color);
 
-  const waypointCount = wire_info.waypoints.length;
-  p.line(ports.start.x, ports.start.y, wire_info.waypoints[0].x, wire_info.waypoints[0].y);
+  const waypointCount = wireInfo.waypoints.length;
+  p.line(ports.start.x, ports.start.y, wireInfo.waypoints[0].x, wireInfo.waypoints[0].y);
   for (let i = 0; i < waypointCount - 1; i++) {
-    p.line(wire_info.waypoints[i].x, wire_info.waypoints[i].y, wire_info.waypoints[i + 1].x, wire_info.waypoints[i + 1].y);
+    p.line(wireInfo.waypoints[i].x, wireInfo.waypoints[i].y, wireInfo.waypoints[i + 1].x, wireInfo.waypoints[i + 1].y);
   }
-  p.line(wire_info.waypoints[waypointCount - 1].x, wire_info.waypoints[waypointCount - 1].y, ports.end.x, ports.end.y);
+  p.line(wireInfo.waypoints[waypointCount - 1].x, wireInfo.waypoints[waypointCount - 1].y, ports.end.x, ports.end.y);
 
   p.stroke(0);
   p.strokeWeight(1);
@@ -157,9 +157,9 @@ export function drawGhostWire(wire, p) {
   p.strokeWeight(1);
 }  
 
-export function drawWaypoint(wire_info, waypoint, p) {
+export function drawWaypoint(wireInfo, waypoint, p) {
   const theme = getActiveTheme();
-  let color = wire_info.wire.signal ? theme.wires.high.hex : theme.wires.low.hex;
+  let color = wireInfo.wire.signal ? theme.wires.high.hex : theme.wires.low.hex;
   p.fill(color);
   p.circle(waypoint.x, waypoint.y, 12);
 }

--- a/render/wireGeometry.js
+++ b/render/wireGeometry.js
@@ -1,6 +1,6 @@
 import { isNearWaypoint } from "../input/mouseHandlers.js";
 
-export function init_wire(renderNodes, wire, custom_waypoints, nodeMap) {
+export function initWire(renderNodes, wire, custom_waypoints, nodeMap) {
   let waypoints;
   let isCustomRouted = false;
   if (custom_waypoints && custom_waypoints.length !== 0) {
@@ -55,12 +55,12 @@ export function computeWayPoints(renderNodes, wire, nodeMap) {
   return waypoints;
 }
 
-export function reComputeWayPoint(renderNodes, wire_info, nodeMap) {
-  if (wire_info.isCustomRouted) return;
-  if (wire_info.wire.to.type === "composite") return;
-  let newWayPoints = computeWayPoints(renderNodes, wire_info.wire, nodeMap);
+export function reComputeWayPoint(renderNodes, wireInfo, nodeMap) {
+  if (wireInfo.isCustomRouted) return;
+  if (wireInfo.wire.to.type === "composite") return;
+  let newWayPoints = computeWayPoints(renderNodes, wireInfo.wire, nodeMap);
   const waypointCount = newWayPoints.length;
-  wire_info.waypoints[waypointCount - 1].y = newWayPoints[waypointCount - 1].y;
+  wireInfo.waypoints[waypointCount - 1].y = newWayPoints[waypointCount - 1].y;
 }
 
 export function setCustomWaypoints(p) {

--- a/render/wireGeometry.js
+++ b/render/wireGeometry.js
@@ -55,7 +55,7 @@ export function computeWayPoints(renderNodes, wire, nodeMap) {
   return waypoints;
 }
 
-export function reComputeWayPoint(renderNodes, wireInfo, nodeMap) {
+export function recomputeWayPoint(renderNodes, wireInfo, nodeMap) {
   if (wireInfo.isCustomRouted) return;
   if (wireInfo.wire.to.type === "composite") return;
   let newWayPoints = computeWayPoints(renderNodes, wireInfo.wire, nodeMap);


### PR DESCRIPTION
## Summary

This PR standardizes naming conventions across the wire and node handling code to improve consistency, readability, and maintainability.

## Changes

* Renamed mixed snake_case and camelCase identifiers to follow a consistent naming convention.
* Standardized variable names:

  * `wire_info` / `wire_infos` naming inconsistencies addressed relative to existing camelCase identifiers such as `renderNodes` and `nodeMap`.
* Standardized function names:

  * `init_wire` updated to align with the naming style used by functions like `computeWayPoints`.
* Fixed inconsistent capitalization in compound-word function names:

  * `reComputeWayPoint`
  * `reBuildNodeMap`

## Motivation

The codebase currently mixes snake_case and camelCase styles and also contains inconsistent capitalization patterns for compound words. These inconsistencies make the code harder to scan and maintain. This PR improves overall code clarity by enforcing a uniform naming style.
