### PR TITLE
Fix/memory collision

### DIFF
--- a/logic/evaluate.js
+++ b/logic/evaluate.js
@@ -362,7 +362,10 @@ export function buildTypedArrays(acc) {
     throw new Error("WASM not initialized. Call initWasm() first.");
   }
 
-  let ptr = 0;
+  // Emscripten stores C global variables (pointers, gate/wire counts) at
+  // offsets 1024–1087 in linear memory. Start our typed arrays after that
+  // region to prevent the C runtime from corrupting circuit data.
+  let ptr = 1088;
 
   // 1-byte arrays
   const gateTypes = new Uint8Array(wasmMemory.buffer, ptr, acc.gateTypes.length);

--- a/tests/composite/upstream-gates-bug.test.js
+++ b/tests/composite/upstream-gates-bug.test.js
@@ -1,0 +1,361 @@
+import { describe, it, expect } from "vitest";
+import { CircuitBuilder } from "../../logic/CircuitBuilder.js";
+
+/**
+ * Reproducer for the bug: composite gates give wrong results when
+ * upstream gates (e.g. XOR for 2's complement) feed into them.
+ */
+
+function halfAdderCircuitData() {
+  const inner = new CircuitBuilder();
+  const A = inner.addBasicGate("input");
+  const B = inner.addBasicGate("input");
+  const xor = inner.addBasicGate("xor");
+  const and = inner.addBasicGate("and");
+  const sum = inner.addBasicGate("output");
+  const carry = inner.addBasicGate("output");
+
+  inner.connectGates(A, xor, 0);
+  inner.connectGates(B, xor, 1);
+  inner.connectGates(xor, sum, 0);
+  inner.connectGates(A, and, 0);
+  inner.connectGates(B, and, 1);
+  inner.connectGates(and, carry, 0);
+  inner.buildFanout();
+
+  return {
+    builder: inner,
+    inputOrder: [A.id, B.id],
+    outputOrder: [sum.id, carry.id],
+  };
+}
+
+function fullAdderCircuitData() {
+  const inner = new CircuitBuilder();
+  const A = inner.addBasicGate("input");
+  const B = inner.addBasicGate("input");
+  const Cin = inner.addBasicGate("input");
+  const ha1 = inner.addCompositeGate("half-adder", halfAdderCircuitData());
+  const ha2 = inner.addCompositeGate("half-adder", halfAdderCircuitData());
+  const orGate = inner.addBasicGate("or");
+  const sum = inner.addBasicGate("output");
+  const carry = inner.addBasicGate("output");
+
+  inner.connectGates(A, ha1, 0);
+  inner.connectGates(B, ha1, 1);
+  inner.connectGates(ha1, ha2, 0, 0); // sum of ha1 -> A of ha2
+  inner.connectGates(Cin, ha2, 1);     // Cin -> B of ha2
+  inner.connectGates(ha2, sum, 0, 0);  // sum of ha2 -> output sum
+  inner.connectGates(ha1, orGate, 0, 1); // carry of ha1 -> OR
+  inner.connectGates(ha2, orGate, 1, 1); // carry of ha2 -> OR
+  inner.connectGates(orGate, carry, 0);
+  inner.buildFanout();
+
+  return {
+    builder: inner,
+    inputOrder: [A.id, B.id, Cin.id],
+    outputOrder: [sum.id, carry.id],
+  };
+}
+
+function fourBitAdderCircuitData() {
+  const inner = new CircuitBuilder();
+  const A0 = inner.addBasicGate("input");
+  const A1 = inner.addBasicGate("input");
+  const A2 = inner.addBasicGate("input");
+  const A3 = inner.addBasicGate("input");
+  const B0 = inner.addBasicGate("input");
+  const B1 = inner.addBasicGate("input");
+  const B2 = inner.addBasicGate("input");
+  const B3 = inner.addBasicGate("input");
+  const Cin = inner.addBasicGate("input");
+
+  const fa0 = inner.addCompositeGate("full-adder", fullAdderCircuitData());
+  const fa1 = inner.addCompositeGate("full-adder", fullAdderCircuitData());
+  const fa2 = inner.addCompositeGate("full-adder", fullAdderCircuitData());
+  const fa3 = inner.addCompositeGate("full-adder", fullAdderCircuitData());
+
+  const S0 = inner.addBasicGate("output");
+  const S1 = inner.addBasicGate("output");
+  const S2 = inner.addBasicGate("output");
+  const S3 = inner.addBasicGate("output");
+  const Cout = inner.addBasicGate("output");
+
+  // FA0: A0, B0, Cin
+  inner.connectGates(A0, fa0, 0);
+  inner.connectGates(B0, fa0, 1);
+  inner.connectGates(Cin, fa0, 2);
+  inner.connectGates(fa0, S0, 0, 0);
+  // FA1: A1, B1, Cout0
+  inner.connectGates(A1, fa1, 0);
+  inner.connectGates(B1, fa1, 1);
+  inner.connectGates(fa0, fa1, 2, 1); // carry chain
+  inner.connectGates(fa1, S1, 0, 0);
+  // FA2: A2, B2, Cout1
+  inner.connectGates(A2, fa2, 0);
+  inner.connectGates(B2, fa2, 1);
+  inner.connectGates(fa1, fa2, 2, 1);
+  inner.connectGates(fa2, S2, 0, 0);
+  // FA3: A3, B3, Cout2
+  inner.connectGates(A3, fa3, 0);
+  inner.connectGates(B3, fa3, 1);
+  inner.connectGates(fa2, fa3, 2, 1);
+  inner.connectGates(fa3, S3, 0, 0);
+  inner.connectGates(fa3, Cout, 0, 1);
+  inner.buildFanout();
+
+  return {
+    builder: inner,
+    inputOrder: [A0.id, A1.id, A2.id, A3.id, B0.id, B1.id, B2.id, B3.id, Cin.id],
+    outputOrder: [S0.id, S1.id, S2.id, S3.id, Cout.id],
+  };
+}
+
+describe("4-bit adder with direct inputs", () => {
+  it("computes 5 + 3 = 8 correctly", () => {
+    const outer = new CircuitBuilder();
+    const A0 = outer.addBasicGate("input"); // 1
+    const A1 = outer.addBasicGate("input"); // 0
+    const A2 = outer.addBasicGate("input"); // 1
+    const A3 = outer.addBasicGate("input"); // 0
+    const B0 = outer.addBasicGate("input"); // 1
+    const B1 = outer.addBasicGate("input"); // 1
+    const B2 = outer.addBasicGate("input"); // 0
+    const B3 = outer.addBasicGate("input"); // 0
+    const Cin = outer.addBasicGate("input"); // 0
+
+    const adder = outer.addCompositeGate("4-bit-adder", fourBitAdderCircuitData());
+    const S0 = outer.addBasicGate("output");
+    const S1 = outer.addBasicGate("output");
+    const S2 = outer.addBasicGate("output");
+    const S3 = outer.addBasicGate("output");
+    const Cout = outer.addBasicGate("output");
+
+    outer.connectGates(A0, adder, 0);
+    outer.connectGates(A1, adder, 1);
+    outer.connectGates(A2, adder, 2);
+    outer.connectGates(A3, adder, 3);
+    outer.connectGates(B0, adder, 4);
+    outer.connectGates(B1, adder, 5);
+    outer.connectGates(B2, adder, 6);
+    outer.connectGates(B3, adder, 7);
+    outer.connectGates(Cin, adder, 8);
+
+    outer.connectGates(adder, S0, 0, 0);
+    outer.connectGates(adder, S1, 0, 1);
+    outer.connectGates(adder, S2, 0, 2);
+    outer.connectGates(adder, S3, 0, 3);
+    outer.connectGates(adder, Cout, 0, 4);
+
+    // 5 = 0101, 3 = 0011 => 8 = 1000
+    A0.setValue(true);  A1.setValue(false); A2.setValue(true);  A3.setValue(false);
+    B0.setValue(true);  B1.setValue(true);  B2.setValue(false); B3.setValue(false);
+    Cin.setValue(false);
+    outer.evaluate();
+
+    expect(S0.output).toBe(false);
+    expect(S1.output).toBe(false);
+    expect(S2.output).toBe(false);
+    expect(S3.output).toBe(true);
+    expect(Cout.output).toBe(false);
+  });
+});
+
+describe("4-bit adder with upstream XOR gates (2's complement)", () => {
+  it("computes A + (~B + 1) with XOR gates before B inputs", () => {
+    const outer = new CircuitBuilder();
+    // A = 5 = 0101
+    const A0 = outer.addBasicGate("input");
+    const A1 = outer.addBasicGate("input");
+    const A2 = outer.addBasicGate("input");
+    const A3 = outer.addBasicGate("input");
+    // B = 3 = 0011
+    const B0 = outer.addBasicGate("input");
+    const B1 = outer.addBasicGate("input");
+    const B2 = outer.addBasicGate("input");
+    const B3 = outer.addBasicGate("input");
+    // SUB signal = 1 (subtract mode: XOR with 1 inverts, Cin=1 for +1)
+    const SUB = outer.addBasicGate("input");
+
+    // XOR gates to conditionally invert B
+    const xor0 = outer.addBasicGate("xor");
+    const xor1 = outer.addBasicGate("xor");
+    const xor2 = outer.addBasicGate("xor");
+    const xor3 = outer.addBasicGate("xor");
+
+    outer.connectGates(B0, xor0, 0);
+    outer.connectGates(SUB, xor0, 1);
+    outer.connectGates(B1, xor1, 0);
+    outer.connectGates(SUB, xor1, 1);
+    outer.connectGates(B2, xor2, 0);
+    outer.connectGates(SUB, xor2, 1);
+    outer.connectGates(B3, xor3, 0);
+    outer.connectGates(SUB, xor3, 1);
+
+    const adder = outer.addCompositeGate("4-bit-adder", fourBitAdderCircuitData());
+    const S0 = outer.addBasicGate("output");
+    const S1 = outer.addBasicGate("output");
+    const S2 = outer.addBasicGate("output");
+    const S3 = outer.addBasicGate("output");
+    const Cout = outer.addBasicGate("output");
+
+    outer.connectGates(A0, adder, 0);
+    outer.connectGates(A1, adder, 1);
+    outer.connectGates(A2, adder, 2);
+    outer.connectGates(A3, adder, 3);
+    outer.connectGates(xor0, adder, 4);
+    outer.connectGates(xor1, adder, 5);
+    outer.connectGates(xor2, adder, 6);
+    outer.connectGates(xor3, adder, 7);
+    outer.connectGates(SUB, adder, 8); // Cin = SUB for 2's complement
+
+    outer.connectGates(adder, S0, 0, 0);
+    outer.connectGates(adder, S1, 0, 1);
+    outer.connectGates(adder, S2, 0, 2);
+    outer.connectGates(adder, S3, 0, 3);
+    outer.connectGates(adder, Cout, 0, 4);
+
+    // 5 - 3 = 2:
+    // A = 0101, B = 0011, SUB = 1
+    // ~B = 1100, ~B+1 = 1101
+    // 0101 + 1101 = 10010, lower 4 bits = 0010 = 2, Cout=1
+    A0.setValue(true);  A1.setValue(false); A2.setValue(true);  A3.setValue(false);
+    B0.setValue(true);  B1.setValue(true);  B2.setValue(false); B3.setValue(false);
+    SUB.setValue(true);
+    outer.evaluate();
+
+    expect(S0.output).toBe(false);  // bit 0
+    expect(S1.output).toBe(true);   // bit 1
+    expect(S2.output).toBe(false);  // bit 2
+    expect(S3.output).toBe(false);  // bit 3
+    expect(Cout.output).toBe(true); // overflow/carry
+  });
+
+  it("computes correctly after toggling inputs", () => {
+    const outer = new CircuitBuilder();
+    const A0 = outer.addBasicGate("input");
+    const A1 = outer.addBasicGate("input");
+    const A2 = outer.addBasicGate("input");
+    const A3 = outer.addBasicGate("input");
+    const B0 = outer.addBasicGate("input");
+    const B1 = outer.addBasicGate("input");
+    const B2 = outer.addBasicGate("input");
+    const B3 = outer.addBasicGate("input");
+    const SUB = outer.addBasicGate("input");
+
+    const xor0 = outer.addBasicGate("xor");
+    const xor1 = outer.addBasicGate("xor");
+    const xor2 = outer.addBasicGate("xor");
+    const xor3 = outer.addBasicGate("xor");
+
+    outer.connectGates(B0, xor0, 0);
+    outer.connectGates(SUB, xor0, 1);
+    outer.connectGates(B1, xor1, 0);
+    outer.connectGates(SUB, xor1, 1);
+    outer.connectGates(B2, xor2, 0);
+    outer.connectGates(SUB, xor2, 1);
+    outer.connectGates(B3, xor3, 0);
+    outer.connectGates(SUB, xor3, 1);
+
+    const adder = outer.addCompositeGate("4-bit-adder", fourBitAdderCircuitData());
+    const S0 = outer.addBasicGate("output");
+    const S1 = outer.addBasicGate("output");
+    const S2 = outer.addBasicGate("output");
+    const S3 = outer.addBasicGate("output");
+    const Cout = outer.addBasicGate("output");
+
+    outer.connectGates(A0, adder, 0);
+    outer.connectGates(A1, adder, 1);
+    outer.connectGates(A2, adder, 2);
+    outer.connectGates(A3, adder, 3);
+    outer.connectGates(xor0, adder, 4);
+    outer.connectGates(xor1, adder, 5);
+    outer.connectGates(xor2, adder, 6);
+    outer.connectGates(xor3, adder, 7);
+    outer.connectGates(SUB, adder, 8);
+
+    outer.connectGates(adder, S0, 0, 0);
+    outer.connectGates(adder, S1, 0, 1);
+    outer.connectGates(adder, S2, 0, 2);
+    outer.connectGates(adder, S3, 0, 3);
+    outer.connectGates(adder, Cout, 0, 4);
+
+    // First: SUB=0, so add mode: 5 + 3 = 8 = 1000
+    A0.setValue(true);  A1.setValue(false); A2.setValue(true);  A3.setValue(false);
+    B0.setValue(true);  B1.setValue(true);  B2.setValue(false); B3.setValue(false);
+    SUB.setValue(false);
+    outer.evaluate();
+
+    expect(S0.output).toBe(false);
+    expect(S1.output).toBe(false);
+    expect(S2.output).toBe(false);
+    expect(S3.output).toBe(true);
+    expect(Cout.output).toBe(false);
+
+    // Now toggle SUB to 1: 5 - 3 = 2 = 0010, Cout=1
+    SUB.setValue(true);
+    outer.evaluate();
+
+    expect(S0.output).toBe(false);
+    expect(S1.output).toBe(true);
+    expect(S2.output).toBe(false);
+    expect(S3.output).toBe(false);
+    expect(Cout.output).toBe(true);
+  });
+});
+
+describe("Wire signal consistency", () => {
+  it("wire signal matches gate output after evaluation", () => {
+    const outer = new CircuitBuilder();
+    const A = outer.addBasicGate("input");
+    const xor = outer.addBasicGate("xor");
+    const B = outer.addBasicGate("input");
+    const out = outer.addBasicGate("output");
+
+    outer.connectGates(A, xor, 0);
+    outer.connectGates(B, xor, 1);
+    outer.connectGates(xor, out, 0);
+
+    A.setValue(true);
+    B.setValue(false);
+    outer.evaluate();
+
+    // Check that the wire from xor to out matches xor's output
+    const wireToOut = outer.wires.find(w => w.to === out);
+    expect(wireToOut.signal).toBe(xor.output);
+    expect(out.output).toBe(true);
+
+    // Toggle
+    B.setValue(true);
+    outer.evaluate();
+    expect(wireToOut.signal).toBe(xor.output);
+    expect(out.output).toBe(false);
+  });
+
+  it("composite gate output wire signal matches composite output after evaluation", () => {
+    const outer = new CircuitBuilder();
+    const A = outer.addBasicGate("input");
+    const B = outer.addBasicGate("input");
+    const ha = outer.addCompositeGate("half-adder", halfAdderCircuitData());
+    const sumOut = outer.addBasicGate("output");
+    const carryOut = outer.addBasicGate("output");
+
+    outer.connectGates(A, ha, 0);
+    outer.connectGates(B, ha, 1);
+    outer.connectGates(ha, sumOut, 0, 0);
+    outer.connectGates(ha, carryOut, 0, 1);
+
+    A.setValue(true);
+    B.setValue(true);
+    outer.evaluate();
+
+    const wireToSum = outer.wires.find(w => w.to === sumOut);
+    const wireToCarry = outer.wires.find(w => w.to === carryOut);
+
+    // Sum should be 0, carry should be 1
+    expect(sumOut.output).toBe(false);
+    expect(carryOut.output).toBe(true);
+    expect(wireToSum.signal).toBe(sumOut.output);
+    expect(wireToCarry.signal).toBe(carryOut.output);
+  });
+});


### PR DESCRIPTION
# fix: WASM memory collision corrupting composite gate evaluation

## Problem

Composite gates produce incorrect outputs when driven by upstream logic gates (e.g. XOR gates for 2's complement subtraction). Two symptoms were observed:

1. **Wrong evaluation results** — A 4-bit adder/subtractor works correctly when inputs are connected directly to the composite gate, but gives wrong results when XOR gates are placed between the inputs and the composite (for conditional bit inversion in 2's complement).
2. **Wire signal glitches** — Output port color sometimes disagrees with its incoming wire signal, indicating data corruption in the WASM evaluation engine.

Both problems are intermittent and depend on circuit size: small circuits work fine, but deeply-nested composites (HA → FA → 4-bit adder = 104 flattened gates, 119 wires) fail.

## Root Cause

**WASM linear memory collision between JS typed arrays and emscripten C globals.**

The `buildTypedArrays()` function in [evaluate.js](file:///home/aditya/code/javascript/GateCraft/logic/evaluate.js#L360) allocates circuit data (gate types, outputs, wire signals, fanin/fanout arrays) directly into WASM shared memory starting at **byte offset 0**:

```js
// BEFORE (bug)
let ptr = 0;
const gateTypes = new Uint8Array(wasmMemory.buffer, ptr, ...);
```

Meanwhile, the emscripten-compiled C code in [evaluate.c](file:///home/aditya/code/javascript/GateCraft/logic/evaluate.c#L4-L24) has 17 global variables (2 `uint16_t` counters + 15 `uint32_t` pointers = 64 bytes). The `emcc -O3` compiler places these at **offsets 1024–1087** in WASM linear memory. When `init()` is called, it writes pointer values to these fixed memory locations:

```wat
;; init() disassembly — stores to offsets 1024–1084
(i32.store16 (i32.const 1024) ...)  ;; gateCount
(i32.store16 (i32.const 1026) ...)  ;; wireCount
(i32.store   (i32.const 1028) ...)  ;; gateTypes ptr
(i32.store   (i32.const 1032) ...)  ;; outputOffset ptr
;; ... 13 more stores up to offset 1084
```

For **small circuits** (< ~200 gates+wires), the typed arrays fit within bytes 0–1023 and don't overlap with the C globals at 1024+. For **large deeply-nested composites** like the 4-bit adder (104 gates, 119 wires), the typed arrays extend past byte 1024, and `init()` **overwrites parts of the circuit data** (specifically `gateTypes`, `allOutputs`, or `wireSignal`) with pointer values.

This causes:
- Gates being evaluated with the wrong type (e.g. an `input` gate getting treated as `xor` because a 4-byte pointer value wrote `0x08` into its type byte)
- Wire signals being silently corrupted mid-evaluation
- Nondeterministic behavior depending on exact circuit topology and layout

### Why direct inputs worked but upstream gates didn't

With direct inputs, the 4-bit adder composite had 95 flattened gates. Adding 4 upstream XOR gates pushed the total to 104 gates + 119 wires, crossing the 1024-byte threshold where the C globals are stored. The extra gates' data landed in the corruption zone.

## Fix

### [evaluate.js](file:///home/aditya/code/javascript/GateCraft/logic/evaluate.js#L365-L368)

Start typed array allocation at offset **1088** (past the C globals region) instead of 0:

```diff
-  let ptr = 0;
+  // Emscripten stores C global variables (pointers, gate/wire counts) at
+  // offsets 1024–1087 in linear memory. Start our typed arrays after that
+  // region to prevent the C runtime from corrupting circuit data.
+  let ptr = 1088;
```

This is a **one-line fix** (plus comments). No changes to the C code or WASM binary needed.

## How I found it

1. Confirmed the bug: JS `settleCircuit()` gives correct results, WASM `evaluate()` gives wrong results for the same circuit — proving the issue is WASM-specific
2. Wrote a JS mirror of the C `evaluateFlat` algorithm using the same pre-computed fanin/fanout arrays — it produces **correct** results, proving the algorithm is correct
3. Compared WASM memory state after evaluation vs expected — found 19 gate value mismatches, all cascading from gate 21 (an internal `input` node) reading `0` instead of `1`
4. Inspected byte 0 of WASM memory: found `[0,0,0,8,...]` — byte 3 should be `0` (input type) but was `8` (XOR type), a telltale sign of a 4-byte pointer write
5. Disassembled the WASM binary and found `init()` stores to offsets 1024–1084, confirming the collision

## Test coverage

The [upstream-gates-bug.test.js](file:///home/aditya/code/javascript/GateCraft/tests/composite/upstream-gates-bug.test.js) file covers:

| Test | Description |
|------|-------------|
| `computes 5 + 3 = 8 correctly` | 4-bit adder with direct inputs (baseline) |
| `computes A + (~B + 1) with XOR gates before B inputs` | **The main bug reproducer** — 2's complement subtraction with upstream XOR gates |
| `computes correctly after toggling inputs` | Verifies correct results when toggling between add/subtract modes |
| `wire signal matches gate output` | Checks that wire signal and gate output stay in sync |
| `composite gate output wire signal matches composite output` | Checks wire/output consistency through composite boundaries |

## Future considerations

> [!IMPORTANT]
> The hardcoded offset `1088` depends on the current emscripten compilation flags (`-O3 --no-entry -s IMPORTED_MEMORY=1`). If the C code adds more globals or the emcc version changes the data layout, this offset may need updating.

A more robust approach for the future would be to either:
- Export `__heap_base` from the WASM module and use it as the starting offset
- Add `-s GLOBAL_BASE=<N>` to the emcc flags to control where C globals are placed, and document the constraint
- Use a separate `WebAssembly.Memory` region for the C globals vs circuit data
