### PR TITLE
Feat/composite gates

### DIFF
--- a/render/RenderPoint.js
+++ b/render/RenderPoint.js
@@ -124,14 +124,18 @@ function computeSize(gate) {
     let maxOutputLabelLen = 0;
     if (gate.internalInputs) {
       for (const g of gate.internalInputs) {
-        const lbl = g.label || g.type;
-        if (lbl.length > maxInputLabelLen) maxInputLabelLen = lbl.length;
+        if (g.label) {
+          const lbl = g.label;
+          if (lbl.length > maxInputLabelLen) maxInputLabelLen = lbl.length;
+        }
       }
     }
     if (gate.internalOutputs) {
       for (const g of gate.internalOutputs) {
-        const lbl = g.label || g.type;
-        if (lbl.length > maxOutputLabelLen) maxOutputLabelLen = lbl.length;
+        if (g.label) {
+          const lbl = g.label;
+          if (lbl.length > maxOutputLabelLen) maxOutputLabelLen = lbl.length;
+        }
       }
     }
 

--- a/render/draw.js
+++ b/render/draw.js
@@ -81,8 +81,13 @@ export function drawOutputPorts(renderNodes, p) {
       p.circle(port.x, port.y, PORT_RADIUS);
 
       // Draw port label for composite gates
-      if (gate.type === "composite" && gate.internalOutputs && gate.internalOutputs[j]) {
-        const portLabel = gate.internalOutputs[j].label || gate.internalOutputs[j].type;
+      if (
+        gate.type === "composite" &&
+        gate.internalOutputs &&
+        gate.internalOutputs[j] &&
+        gate.internalOutputs[j].label
+      ) {
+        const portLabel = gate.internalOutputs[j].label;
         p.noStroke();
         p.fill(theme.text.muted ? theme.text.muted.hex : "#94a3b8");
         p.textSize(PORT_LABEL_SIZE);
@@ -111,8 +116,13 @@ export function drawInputPorts(renderNodes, p) {
       p.circle(port.x, port.y, PORT_RADIUS);
 
       // Draw port label for composite gates
-      if (gate.type === "composite" && gate.internalInputs && gate.internalInputs[j]) {
-        const portLabel = gate.internalInputs[j].label || gate.internalInputs[j].type;
+      if (
+        gate.type === "composite" &&
+        gate.internalInputs &&
+        gate.internalInputs[j] &&
+        gate.internalInputs[j].label
+      ) {
+        const portLabel = gate.internalInputs[j].label;
         p.noStroke();
         p.fill(theme.text.muted ? theme.text.muted.hex : "#94a3b8");
         p.textSize(PORT_LABEL_SIZE);


### PR DESCRIPTION
# Fix composite gate port label rendering and sizing

## Summary

This PR updates composite gate port label handling to only use explicitly defined labels.

### Changes

* Render input and output port labels only when a custom `label` is provided.
* Remove the fallback to the port `type` when displaying labels.
* Update composite gate size calculations to consider only explicit labels when determining the required width.
* Prevent unlabeled ports from increasing gate width unnecessarily.

## Before

* Ports without a custom label displayed their `type` as the label.
* Gate sizing calculations included port types, which could make composite gates wider than necessary.

## After

* Only user-defined labels are rendered.
* Unlabeled ports do not contribute to label width calculations.
* Composite gates are sized according to the labels that are actually displayed.