### PR TITLE
refactor: render ports as part of gate drawing

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -16,4 +16,4 @@ export const FONT_SIZE = 16;
 export const PORT_LABEL_SIZE = 14;
 export const GRID_OFFSET = 5;
 export const GRID_SIZE = 20;
-export const PORT_RADIUS = 10;
+export const PORT_RADIUS = 11;

--- a/render/draw.js
+++ b/render/draw.js
@@ -19,11 +19,18 @@ function contrastText(hex) {
 }
 
 export function drawGate(renderNode, p) {
+  const theme = getActiveTheme();
   if (renderNode.gate.type === "seven-seg") {
     drawDisplay(renderNode, p);
+    drawInputPort(renderNode, theme, p);
+    drawOutputPort(renderNode, theme, p);
+    
+    p.fill(0);
+    p.stroke(0);
+    p.strokeWeight(1);
     return;
   }
-  const theme = getActiveTheme();
+  
   const gate = renderNode.gate;
   const isOn = Array.isArray(gate.output) ? gate.output.some(Boolean) : gate.output;
   let color;
@@ -62,6 +69,9 @@ export function drawGate(renderNode, p) {
   } else {
     p.text(label, renderNode.x + renderNode.width / 2, renderNode.y + renderNode.height / 2);
   }
+
+  drawOutputPort(renderNode, theme, p);
+  drawInputPort(renderNode, theme, p);
 
   p.fill(0);
   p.stroke(0);
@@ -255,44 +265,32 @@ export function drawWire(renderNodes, wireInfo, nodeMap, p) {
   p.strokeWeight(1);
 }
 
-export function drawOutputPorts(renderNodes, p) {
-  const theme = getActiveTheme();
-  for (let i = 0; i < renderNodes.length; i++) {
-    const gate = renderNodes[i].gate;
-    if (gate.type === "output") continue;
-    const totalOutputs = gate.outputCount;
+function drawOutputPort(renderNode, theme, p) {
+  const gate = renderNode.gate;
+  if (gate.type === "output") return;
+  const totalOutputs = gate.outputCount;
 
-    for (let j = 0; j < totalOutputs; j++) {
-      const port = renderNodes[i].getOutputPortByIndex(j, totalOutputs);
-      p.fill(theme.accent.hex);
-      p.stroke(theme.text.primary.hex);
-      p.strokeWeight(1.5);
-      p.circle(port.x, port.y, PORT_RADIUS);
-    }
+  for (let i = 0; i < totalOutputs; i++) {
+    const port = renderNode.getOutputPortByIndex(i, totalOutputs);
+    p.fill(theme.accent.hex);
+    p.stroke(theme.text.primary.hex);
+    p.strokeWeight(1.5);
+    p.circle(port.x, port.y, PORT_RADIUS);
   }
-  p.fill(0);
-  p.stroke(0);
-  p.strokeWeight(1);
 }
 
-export function drawInputPorts(renderNodes, p) {
-  const theme = getActiveTheme();
-  for (let i = 0; i < renderNodes.length; i++) {
-    const gate = renderNodes[i].gate;
-    if (gate.type === "input" || gate.type === "clock") continue;
-    const totalInputs = gate.inputCount;
+function drawInputPort(renderNode, theme, p) {
+  const gate = renderNode.gate;
+  if (gate.type === "input" || gate.type === "clock") return;
+  const totalInputs = gate.inputCount;
 
-    for (let j = 0; j < totalInputs; j++) {
-      const port = renderNodes[i].getInputPortByIndex(j, totalInputs);
-      p.fill(theme.accent.hex);
-      p.stroke(theme.text.primary.hex);
-      p.strokeWeight(1.5);
-      p.circle(port.x, port.y, PORT_RADIUS);
-    }
+  for (let i = 0; i < totalInputs; i++) {
+    const port = renderNode.getInputPortByIndex(i, totalInputs);
+    p.fill(theme.accent.hex);
+    p.stroke(theme.text.primary.hex);
+    p.strokeWeight(1.5);
+    p.circle(port.x, port.y, PORT_RADIUS);
   }
-  p.fill(0);
-  p.stroke(0);
-  p.strokeWeight(1);
 }
 
 export function drawGhostWire(wire, p) {

--- a/sketch.js
+++ b/sketch.js
@@ -1,5 +1,5 @@
 import { state } from "./state.js";
-import { drawGate, drawWaypoint, drawGhostWire, drawInputPorts, drawOutputPorts, drawWire, drawPortTooltip, setFont, createGrid } from "./render/draw.js";
+import { drawGate, drawWaypoint, drawGhostWire, drawWire, drawPortTooltip, setFont, createGrid } from "./render/draw.js";
 import { registerMouseHandlers, isNearWaypoint, isNearPort } from "./input/mouseHandlers.js";
 import { initToolbar } from "./ui/toolbar.js";
 import { getActiveTheme, applyTheme } from "./render/theme.js";
@@ -56,8 +56,6 @@ const sketch = (p) => {
     for (let i = 0; i < renderNodes.length; i++) {
       drawGate(renderNodes[i], p);
     }
-    drawOutputPorts(renderNodes, p);
-    drawInputPorts(renderNodes, p);
 
     // ── Detect hovered port for tooltip ──────────────────────
     let hoveredPort = null;


### PR DESCRIPTION
# Render Ports as Part of Gate Drawing

Closes #99 

## Summary

This PR refactors gate rendering so that ports are drawn as part of the gate itself instead of in separate rendering passes.

Previously, gate bodies were rendered by `drawGate()` while ports were rendered later by `drawInputPorts()` and `drawOutputPorts()`. This caused visual layering issues when gates overlapped and prevented ports from being displayed during ghost-node placement.

## Changes

* Move input port rendering into `drawGate()`
* Move output port rendering into `drawGate()`
* Replace `drawInputPorts()` and `drawOutputPorts()` with internal helper functions
* Remove separate port rendering passes from `sketch.js`
* Render ports for seven-segment displays through the same rendering path
* Increase `PORT_RADIUS` from 10 to 11

## Fixes

### Gate Layering Issues

Ports are now rendered together with their parent gate, ensuring that gates and ports behave as a single visual entity. This prevents ports from underlying gates appearing above gates that are being dragged or placed.

### Ghost Node Rendering

Ports are now visible during gate placement previews because they are rendered through the same path used for normal gate rendering.

## Result

* Consistent gate and port rendering order
* Correct visual stacking when gates overlap
* Ports visible during ghost-node placement
* Simpler rendering pipeline with a single source of truth for gate rendering
