### PR TITLE
Feat/keyboard shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,9 @@
 
     <div class="topbar-center">
       <div class="mode-switcher" id="mode-switcher">
-        <button class="mode-btn active" data-mode="edit" id="btn-edit">Edit</button>
-        <button class="mode-btn" data-mode="run" id="btn-run">Run</button>
-        <button class="mode-btn" data-mode="delete" id="btn-delete">Delete</button>
+        <button class="mode-btn active" data-mode="edit" id="btn-edit" title="Edit (1)" aria-keyshortcuts="1">Edit</button>
+        <button class="mode-btn" data-mode="run" id="btn-run" title="Run (2)" aria-keyshortcuts="2">Run</button>
+        <button class="mode-btn" data-mode="delete" id="btn-delete" title="Delete (3)" aria-keyshortcuts="3">Delete</button>
       </div>
     </div>
 
@@ -40,7 +40,7 @@
       <span id="modeDisplay" class="mode-display">Mode: Edit</span>
 
       <!-- Save circuit as composite gate -->
-      <button class="save-gate-btn" id="btn-save-gate" title="Save circuit as composite gate">
+      <button class="save-gate-btn" id="btn-save-gate" title="Save circuit as composite gate (Ctrl + S)">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round">
           <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
@@ -50,7 +50,7 @@
         Save as Gate
       </button>
 
-      <button class="save-gate-btn" id="btn-clear-canvas" title="Clear canvas">
+      <button class="save-gate-btn" id="btn-clear-canvas" title="Clear canvas (Ctrl + Shift + X)">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round">
           <polyline points="3 6 5 6 21 6" />
@@ -62,7 +62,7 @@
         Clear
       </button>
 
-      <button class="icon-btn" id="btn-settings" title="Settings" aria-label="Settings">
+      <button class="icon-btn" id="btn-settings" title="Settings (Ctrl + ,)" aria-label="Settings">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
           stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="3" />
@@ -77,7 +77,7 @@
   <aside class="sidebar" id="sidebar">
     <div class="sidebar-header">
       <span class="sidebar-title">Digital Component Palette</span>
-      <button class="sidebar-collapse-btn" id="sidebar-collapse-btn" title="Collapse sidebar" aria-label="Collapse sidebar">
+      <button class="sidebar-collapse-btn" id="sidebar-collapse-btn" title="Collapse sidebar (Tab)" aria-label="Collapse sidebar" aria-keyshortcuts="Tab">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
           stroke-linecap="round" stroke-linejoin="round">
           <polyline points="15 18 9 12 15 6" />
@@ -183,7 +183,7 @@
   </aside>
 
   <!-- Sidebar expand button (visible when collapsed) -->
-  <button class="sidebar-expand-btn" id="sidebar-expand-btn" title="Expand sidebar" aria-label="Expand sidebar">
+  <button class="sidebar-expand-btn" id="sidebar-expand-btn" title="Expand sidebar (Tab)" aria-label="Expand sidebar" aria-keyshortcuts="Tab">
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
       stroke-linecap="round" stroke-linejoin="round">
       <polyline points="9 18 15 12 9 6" />

--- a/index.html
+++ b/index.html
@@ -204,6 +204,18 @@
     </div>
   </div>
 
+  <!-- Clear canvas modal -->
+  <div class="modal-overlay" id="clear-warning-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div class="modal-card">
+      <h3 class="modal-title" id="modal-title">Clear Canvas</h3>
+      <p class="modal-desc">Remove all gates, wires and components from the canvas?</p>
+      <div class="modal-actions">
+        <button class="modal-btn cancel" id="clear-cancel-btn">Cancel</button>
+        <button class="modal-btn confirm" id="clear-confirm-btn">Clear canvas</button>
+      </div>
+    </div>
+  </div>
+
   <!-- ── Settings Panel ─────────────────────────────────────── -->
   <div class="settings-overlay" id="settings-overlay">
     <div class="settings-panel" id="settings-panel">

--- a/input/keyboardHandlers.js
+++ b/input/keyboardHandlers.js
@@ -1,26 +1,45 @@
 import { state } from "../state.js";
 import { changeMode, toggleSidebar } from "../ui/toolbar.js";
 
-const shortcuts = {
-  "1": () => changeMode("edit"),
-  "2": () => changeMode("run"),
-  "3": () => changeMode("delete"),
-  "tab": () => toggleSidebar(),
-}
-
 function buildKeyCombo(p) {
   const parts = [];
+  if (p.keyIsDown(p.CONTROL) || p.keyIsDown(91)) parts.push("control");
+  if (p.keyIsDown(p.SHIFT)) parts.push("shift");
   parts.push(p.key.toLowerCase());
 
   return parts.join("+");
 }
 
-export function registerKeyboardHandlers(p, circuit, renderNodes, wires) {
+export function registerKeyboardHandlers(p, circuit, renderNodes, wires, actions) {
+  // 1. Canvas-specific tool shortcuts (only active when the canvas has focus)
+  const shortcuts = {
+    "1": () => changeMode("edit"),
+    "2": () => changeMode("run"),
+    "3": () => changeMode("delete"),
+    "tab": () => toggleSidebar(),
+    "control+s": () => actions.openSaveModal(),
+    "control+shift+x": () => actions.openWarningModal(),
+    "control+,": () => actions.openSettings(),
+  }
+
   p.keyPressed = function (event) {
     if (state.labelEditing) return;
-    if (document.activeElement?.tagName === "INPUT") return;
+    if (document.activeElement?.tagName === "INPUT" && event.key !== "Escape") return;
 
     const combo = buildKeyCombo(p);
     shortcuts[combo]?.();
-  }
+  };
+
+  // 2. Native Global Escape Listener
+  // This runs independently of p5 canvas focus, catching Escape even inside active inputs!
+  window.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && state.isAnyModalOpen) {
+      e.preventDefault();
+      actions.closeAllModals();
+    }
+  });
+
+  window.addEventListener("keydown", (e) => {
+    if (e.ctrlKey && e.key === "s") e.preventDefault();
+  });
 }

--- a/input/keyboardHandlers.js
+++ b/input/keyboardHandlers.js
@@ -1,0 +1,27 @@
+import { state } from "../state.js";
+import { changeMode, toggleSidebar } from "../ui/toolbar.js";
+
+const shortcuts = {
+  "1": () => changeMode("edit"),
+  "2": () => changeMode("run"),
+  "3": () => changeMode("delete"),
+  "tab": () => toggleSidebar(),
+}
+
+function buildKeyCombo(p) {
+  const parts = [];
+  parts.push(p.key.toLowerCase());
+
+  return parts.join("+");
+}
+
+export function registerKeyboardHandlers(p, circuit, renderNodes, wires) {
+  p.keyPressed = function (event) {
+    if (state.labelEditing) return;
+    if (document.activeElement?.tagName === "INPUT") return;
+
+    const combo = buildKeyCombo(p);
+    console.log(combo);
+    shortcuts[combo]?.();
+  }
+}

--- a/input/keyboardHandlers.js
+++ b/input/keyboardHandlers.js
@@ -21,7 +21,6 @@ export function registerKeyboardHandlers(p, circuit, renderNodes, wires) {
     if (document.activeElement?.tagName === "INPUT") return;
 
     const combo = buildKeyCombo(p);
-    console.log(combo);
     shortcuts[combo]?.();
   }
 }

--- a/sketch.js
+++ b/sketch.js
@@ -37,7 +37,10 @@ const sketch = (p) => {
   p.setup = function () {
     const cnv = p.createCanvas(WIDTH, HEIGHT);
     cnv.parent(canvasHost);
-    initToolbar(p, circuit, renderNodes, wires);
+    const toolbarActions = initToolbar(p, circuit, renderNodes, wires);
+
+    registerMouseHandlers(p, circuit, renderNodes, wires);
+    registerKeyboardHandlers(p, circuit, renderNodes, wires, toolbarActions);
 
     const theme = getActiveTheme();    
     gridBuffer = createGrid(WIDTH, HEIGHT, theme, GRID_OFFSET, GRID_SIZE, p);
@@ -161,9 +164,6 @@ const sketch = (p) => {
       drawPortTooltip(tooltipState.label, tooltipState.port, tooltipState.opacity, tooltipState.portType, p);
     }
   }
-
-  registerMouseHandlers(p, circuit, renderNodes, wires);
-  registerKeyboardHandlers(p, circuit, renderNodes, wires);
 }
 
 new p5(sketch);

--- a/sketch.js
+++ b/sketch.js
@@ -7,6 +7,7 @@ import { CircuitBuilder } from "./logic/CircuitBuilder.js";
 import { nodeMap } from "./input/mouseHandlers.js";
 import { GRID_OFFSET, GRID_SIZE } from "./constants.js";
 import { snapPointToGrid, wouldOverlap } from "./render/RenderPoint.js";
+import { registerKeyboardHandlers } from "./input/keyboardHandlers.js";
 
 let gridBuffer;
 applyTheme(getActiveTheme());
@@ -162,6 +163,7 @@ const sketch = (p) => {
   }
 
   registerMouseHandlers(p, circuit, renderNodes, wires);
+  registerKeyboardHandlers(p, circuit, renderNodes, wires);
 }
 
 new p5(sketch);

--- a/state.js
+++ b/state.js
@@ -17,6 +17,7 @@ const _state = {
   connectedWiresWaypoints: null,
   labelEditing: false,
   gridDirty: false,
+  isAnyModalOpen: false,
 };
 
 /**

--- a/ui/modal.js
+++ b/ui/modal.js
@@ -1,0 +1,28 @@
+export function createModal({ overlay, focusElement, onConfirm, onCancel, onOpen, onClose }) {
+  function open() {
+    overlay.classList.add("open");
+    focusElement?.focus();
+    onOpen?.();
+  }
+
+  function close() {
+    overlay.classList.remove("open");
+    onClose?.();
+  }
+
+  function confirm(...args) {
+    const result = onConfirm?.(...args);
+    if (result !== false) close();
+  }
+
+  function cancel(...args) {
+    onCancel(...args);
+    close();
+  }
+
+  overlay.addEventListener("click", e => {
+    if (e.target === overlay) close();
+  });
+
+  return { open, close, confirm, cancel };
+}

--- a/ui/modal.js
+++ b/ui/modal.js
@@ -1,13 +1,17 @@
+import { state } from "../state.js";
+
 export function createModal({ overlay, focusElement, onConfirm, onCancel, onOpen, onClose }) {
   function open() {
     overlay.classList.add("open");
     focusElement?.focus();
     onOpen?.();
+    state.isAnyModalOpen = true;
   }
 
   function close() {
     overlay.classList.remove("open");
     onClose?.();
+    state.isAnyModalOpen = false;
   }
 
   function confirm(...args) {

--- a/ui/toolbar.js
+++ b/ui/toolbar.js
@@ -108,6 +108,11 @@ function expandSidebar() {
   sidebarExpandBtn.classList.remove("visible");
 }
 
+export function toggleSidebar() {
+  if (sidebar.classList.contains("collapsed")) expandSidebar();
+  else collapseSidebar();
+}
+
 sidebarCollapseBtn.addEventListener("click", collapseSidebar);
 sidebarExpandBtn.addEventListener("click", expandSidebar);
 
@@ -155,6 +160,7 @@ document.addEventListener("contextmenu", (e) => {
 });
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape") hideContextMenu();
+  if (e.key === "Tab") e.preventDefault();
 });
 
 // Context menu actions
@@ -292,6 +298,13 @@ function refreshCompositeSection() {
   });
 }
 
+export function changeMode(mode) {
+  state.mode = mode;
+  document.querySelectorAll(".mode-btn").forEach(b => b.classList.remove("active"));
+  const btnId = `#btn-${mode}`;
+  document.querySelector(btnId).classList.add("active");
+}
+
 // ─── Main init ──────────────────────────────────────────────────
 export function initToolbar(p, circuit, renderNodes, wires) {
   _renderNodes = renderNodes;
@@ -300,9 +313,7 @@ export function initToolbar(p, circuit, renderNodes, wires) {
   // Segmented mode switcher
   document.querySelectorAll(".mode-btn").forEach(btn => {
     btn.addEventListener("click", () => {
-      state.mode = btn.dataset.mode;
-      document.querySelectorAll(".mode-btn").forEach(b => b.classList.remove("active"));
-      btn.classList.add("active");
+      changeMode(btn.dataset.mode);
     });
   });
 

--- a/ui/toolbar.js
+++ b/ui/toolbar.js
@@ -402,4 +402,11 @@ export function initToolbar(p, circuit, renderNodes, wires) {
     const el = e.target.closest("[data-tooltip]");
     if (el) hideTooltip();
   }, true);
+
+  return {
+    openSaveModal: () => saveModal.open(),
+    openWarningModal: () => warningModal.open(),
+    openSettings: () => settingsModal.open(),
+    closeAllModals: () => { saveModal.close(); warningModal.close(); settingsModal.close(); },
+  }
 }

--- a/ui/toolbar.js
+++ b/ui/toolbar.js
@@ -129,11 +129,18 @@ function showContextMenu(e, name) {
   ctxMenu.style.left = `${x}px`;
   ctxMenu.style.top = `${y}px`;
   ctxMenu.classList.add("open");
+
+  state.isAnyModalOpen = true;
 }
 
 function hideContextMenu() {
+  // Only modify state if the context menu is actually open
+  if (!ctxMenu.classList.contains("open")) return;
+
   ctxMenu.classList.remove("open");
   _ctxTargetName = null;
+
+  state.isAnyModalOpen = false;
 }
 
 // Close context menu on any click or Escape
@@ -302,6 +309,7 @@ export function initToolbar(p, circuit, renderNodes, wires) {
 
   const warningModal = createModal({
     overlay: clearWarningModal,
+    focusElement: clearConfirm,
     onConfirm: () => clearCanvas(circuit),
     onOpen: () => p.noLoop(),
     onClose: () => p.loop(),
@@ -325,7 +333,7 @@ export function initToolbar(p, circuit, renderNodes, wires) {
     overlay: settingsOverlay,
     onOpen: () => { renderThemeGrid(); p.noLoop() },
     onClose: () => p.loop(),
-  })
+  });
 
   // Segmented mode switcher
   document.querySelectorAll(".mode-btn").forEach(btn => {

--- a/ui/toolbar.js
+++ b/ui/toolbar.js
@@ -9,6 +9,7 @@ import {
   buildCircuitFromData,
 } from "../persistence.js";
 import { themes, getActiveThemeId, setActiveThemeId } from "../render/theme.js";
+import { createModal } from "./modal.js";
 
 
 
@@ -17,6 +18,10 @@ const modal = document.getElementById("save-gate-modal");
 const modalInput = document.getElementById("gate-name-input");
 const modalSave = document.getElementById("modal-save-btn");
 const modalCancel = document.getElementById("modal-cancel-btn");
+
+const clearWarningModal = document.getElementById("clear-warning-modal");
+const clearCancel = document.getElementById("clear-cancel-btn");
+const clearConfirm = document.getElementById("clear-confirm-btn");
 
 let _renderNodes = null;
 let _wires = null;
@@ -31,29 +36,10 @@ function clearCanvas(circuit) {
   _wires.splice(0, _wires.length);
 }
 
-function openSaveModal() {
-  modalInput.value = "";
-  modal.classList.add("open");
-  modalInput.focus();
-}
-
-function closeSaveModal() {
-  modal.classList.remove("open");
-}
-
 // ─── Settings panel helpers ─────────────────────────────────────
 const settingsOverlay = document.getElementById("settings-overlay");
 const settingsCloseBtn = document.getElementById("settings-close-btn");
 const themeGrid = document.getElementById("theme-grid");
-
-function openSettings() {
-  settingsOverlay.classList.add("open");
-  renderThemeGrid();
-}
-
-function closeSettings() {
-  settingsOverlay.classList.remove("open");
-}
 
 function renderThemeGrid() {
   themeGrid.innerHTML = "";
@@ -305,10 +291,41 @@ export function changeMode(mode) {
   document.querySelector(btnId).classList.add("active");
 }
 
+
+const saveAsCompositeBtn = document.getElementById("btn-save-gate");
+const clearBtn = document.getElementById("btn-clear-canvas");
+const settingsBtn = document.getElementById("btn-settings");
 // ─── Main init ──────────────────────────────────────────────────
 export function initToolbar(p, circuit, renderNodes, wires) {
   _renderNodes = renderNodes;
   _wires = wires;
+
+  const warningModal = createModal({
+    overlay: clearWarningModal,
+    onConfirm: () => clearCanvas(circuit),
+    onOpen: () => p.noLoop(),
+    onClose: () => p.loop(),
+  });
+
+  const saveModal = createModal({
+    overlay: modal,
+    focusElement: modalInput,
+    onConfirm: () => {
+      const name = modalInput.value.trim();
+      if (!name) { modalInput.focus(); return false; };
+      saveCompositeGate(name, _renderNodes, _wires);
+      clearCanvas(circuit);
+      refreshCompositeSection();
+    },
+    onOpen: () => { modalInput.value = ""; p.noLoop() },
+    onClose: () => p.loop(),
+  });
+
+  const settingsModal = createModal({
+    overlay: settingsOverlay,
+    onOpen: () => { renderThemeGrid(); p.noLoop() },
+    onClose: () => p.loop(),
+  })
 
   // Segmented mode switcher
   document.querySelectorAll(".mode-btn").forEach(btn => {
@@ -327,51 +344,23 @@ export function initToolbar(p, circuit, renderNodes, wires) {
     });
   });
 
-  // Save-as-composite button
-  document.getElementById("btn-save-gate").addEventListener("click", () => {
-    openSaveModal();
-    p.noLoop();
-  });
-
-  // Modal cancel
-  modalCancel.addEventListener("click", () => {
-    closeSaveModal();
-    p.loop();
-  });
-
-  // Modal save
-  modalSave.addEventListener("click", () => {
-    const name = modalInput.value.trim();
-    if (!name) { modalInput.focus(); return; }
-    saveCompositeGate(name, _renderNodes, _wires);
-    closeSaveModal();
-    p.loop();
-    clearCanvas(circuit);
-    refreshCompositeSection();
-  });
-
-  // Allow Enter key in the name field
+  // ─── Save as composite ────────────────────────────────────────
+  saveAsCompositeBtn.addEventListener("click", () => saveModal.open());
+  modalCancel.addEventListener("click", () => saveModal.close());
+  modalSave.addEventListener("click", () => saveModal.confirm());
   modalInput.addEventListener("keydown", e => {
-    if (e.key === "Enter") modalSave.click();
-    if (e.key === "Escape") closeSaveModal();
-  });
-
-  // Click outside modal to close
-  modal.addEventListener("click", e => {
-    if (e.target === modal) closeSaveModal();
+    if (e.key === "Enter") saveModal.confirm();
+    else if (e.key === "Escape") saveModal.close();
   });
 
   // ─── Clear canvas ─────────────────────────────────────────────
-  document.getElementById("btn-clear-canvas").addEventListener("click", () => {
-    clearCanvas(circuit);
-  });
+  clearBtn.addEventListener("click", () => warningModal.open());
+  clearCancel.addEventListener("click", () => warningModal.close());
+  clearConfirm.addEventListener("click", () => warningModal.confirm());
 
   // ─── Settings panel ────────────────────────────────────────────
-  document.getElementById("btn-settings").addEventListener("click", openSettings);
-  settingsCloseBtn.addEventListener("click", closeSettings);
-  settingsOverlay.addEventListener("click", e => {
-    if (e.target === settingsOverlay) closeSettings();
-  });
+  settingsBtn.addEventListener("click", () => settingsModal.open());
+  settingsCloseBtn.addEventListener("click", () => settingsModal.close());
 
   // Initial population of composite section
   refreshCompositeSection();


### PR DESCRIPTION
# Pull Request: Keyboard Shortcuts, Modal Refactoring & Clear Canvas Confirmation

## 🚀 Overview
This PR introduces comprehensive keyboard shortcuts for fast navigation and actions, implements a robust global modal state management system, and refactors all existing dialogs into a unified modal utility. It enhances accessibility and user experience by providing quick keystroke access to core application features and preventing accidental canvas clearing with a new confirmation dialog.

## 🌟 New Features
* **Global Keyboard Shortcuts**: Implemented intuitive shortcuts for core actions (handled via `input/keyboardHandlers.js`):
  * `1` / `2` / `3`: Switch to **Edit**, **Run**, and **Delete** modes.
  * `Tab`: Toggle the Sidebar (collapse/expand).
  * `Ctrl + S`: Open the "Save as Gate" modal.
  * `Ctrl + Shift + X`: Clear the canvas.
  * `Ctrl + ,`: Open the Settings panel.
* **Clear Canvas Confirmation**: Added a new confirmation dialog (`clear-warning-modal`) when clearing the canvas to prevent accidental data loss.
* **Accessibility & Visual Hints**: Updated the `index.html` toolbar and sidebar buttons with `aria-keyshortcuts` and `title` attributes to visually display keyboard shortcuts in tooltips.
* **Native Override**: Disabled the browser's default behavior for `Ctrl + S` to seamlessly map it to the "Save Gate" action without opening the browser's save prompt.

## 🛠 Technical Improvements & Refactoring
* **Reusable Modal Utility (`ui/modal.js`)**: Created a new `createModal` function that centralizes modal lifecycle management. It standardizes the `open`, `close`, `confirm`, and `cancel` methods and handles overlay clicks and autofocus automatically.
* **Modal Migrations**: Successfully migrated the **Save Gate** modal, **Settings** panel, and the new **Clear Canvas** dialog in `ui/toolbar.js` to use the unified `createModal` API.
* **Global Modal State (`state.js`)**: Introduced `state.isAnyModalOpen` to track when UI overlays or context menus are active.
* **Robust Escape Handling**: Added a native `window.addEventListener` for the `Escape` key that ignores canvas focus and actively running inputs. This allows users to reliably close any active modal or context menu instantly, even if they are typing inside a text input.
* **Input Field Safety**: Keydown handlers are now smart enough to safely ignore standard shortcuts (like `1`, `2`, `3`) if the user is actively focused on an `<input>` field.

## 📂 Key Files Modified
- `input/keyboardHandlers.js`: Contains the new shortcut bindings, input safety checks, and global `Escape` listeners.
- `ui/modal.js`: Contains the new reusable modal creation wrapper.
- `ui/toolbar.js`: Migrated dialogs to `createModal` and integrated clear canvas logic.
- `index.html`: Added the markup for the `clear-warning-modal` and injected accessibility/shortcut hints.
- `state.js`: Added the `isAnyModalOpen` property.
