### PR TITLE
fix: bring selected gate to front while dragging

### DIFF
--- a/input/mouseHandlers.js
+++ b/input/mouseHandlers.js
@@ -21,6 +21,7 @@ export function registerMouseHandlers(p, circuit, renderNodes, wires) {
       state.justPlacedFromToolbar = false;
     }
     state.dragging = renderNodes.find(n => n.containsPoint(p.mouseX, p.mouseY));
+    bringToFront(renderNodes, state.dragging);
 
     if (state.mode === "edit") {
       // Check input ports
@@ -351,6 +352,13 @@ function findNearWaypoint(mx, my, p, wires) {
     }
   }
   return null;
+}
+
+function bringToFront(renderNodes, node) {
+  const idx = renderNodes.indexOf(node);
+  if (idx === -1) return;
+  renderNodes.splice(idx, 1);
+  renderNodes.push(node);
 }
 
 /**


### PR DESCRIPTION
## Summary

Update the drag behavior so the selected gate is always rendered above other gates. When a drag begins, the selected gate is removed from its current position in the `renderNodes` array and appended to the end. Since gates are rendered in array order, mutating the array in this way ensures the active gate is drawn last and remains visible while being moved.

Closes #104
