### PR TITLE
Feat/straight wires

### DIFF
--- a/input/mouseHandlers.js
+++ b/input/mouseHandlers.js
@@ -93,7 +93,11 @@ export function registerMouseHandlers(p, circuit, renderNodes, wires) {
             }
           }
         } else if (state.drawingWire && !state.changingWayPoint && !state.dragging) {
-          const { waypoints, cleanup } = setCustomWaypoints(p);
+          const fromNode = state.drawingWire.fromNode;
+          const startPort = fromNode.gate.type === "composite"
+            ? fromNode.getOutputPortByIndex(state.drawingWire.fromOutputIndex, fromNode.gate.outputCount)
+            : fromNode.getOutputPort();
+          const { waypoints, cleanup } = setCustomWaypoints(p, startPort);
           state.ghostWire = waypoints;
           state.ghostWireCleanup = cleanup;
         } else if (!state.drawingWire && !state.changingWayPoint && !state.dragging) {

--- a/render/draw.js
+++ b/render/draw.js
@@ -493,6 +493,30 @@ function drawInputPort(renderNode, theme, p) {
   }
 }
 
+export function getOctilinearSnap(x1, y1, x2, y2) {
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+
+  const ax = Math.abs(dx);
+  const ay = Math.abs(dy);
+
+  const TAN30 = Math.tan(30 * Math.PI / 180);
+  const TAN60 = Math.tan(60 * Math.PI / 180);
+
+  let x = x2;
+  let y = y2;
+
+  if (ay <= ax * TAN30) y = y1;
+  else if (ay >= ax * TAN60) x = x1;
+  else {
+    const d = Math.min(ax, ay);
+    x = x1 + Math.sign(dx) * d;
+    y = y1 + Math.sign(dy) * d;
+  }
+
+  return { x, y };
+}
+
 export function drawGhostWire(wire, p) {
   const theme = getActiveTheme();
   const node = wire.fromNode;
@@ -507,15 +531,28 @@ export function drawGhostWire(wire, p) {
   p.stroke(theme.wires.ghost.hex);
   p.strokeWeight(3);
   const mouseWorld = screenToWorld(p.mouseX, p.mouseY);
+  const useSnap = p.keyIsDown(p.SHIFT);
   if (state.ghostWire && state.ghostWire.length !== 0) {
     p.line(start.x, start.y, state.ghostWire[0].x, state.ghostWire[0].y);
     const waypoint_count = state.ghostWire.length;
     for (let i = 0; i < waypoint_count - 1; i++) {
       p.line(state.ghostWire[i].x, state.ghostWire[i].y, state.ghostWire[i + 1].x, state.ghostWire[i + 1].y);
     }
-    p.line(state.ghostWire[waypoint_count - 1].x, state.ghostWire[waypoint_count - 1].y, mouseWorld.x, mouseWorld.y);
+    const x1 = state.ghostWire[waypoint_count - 1].x;
+    const y1 = state.ghostWire[waypoint_count - 1].y;
+
+    const endX = useSnap ? getOctilinearSnap(x1, y1, mouseWorld.x, mouseWorld.y).x : mouseWorld.x;
+    const endY = useSnap ? getOctilinearSnap(x1, y1, mouseWorld.x, mouseWorld.y).y : mouseWorld.y;
+    p.line(x1, y1, endX, endY);
+    
   } else {
-    p.line(start.x, start.y, mouseWorld.x, mouseWorld.y);
+    const x1 = start.x;
+    const y1 = start.y;
+
+    const endX = useSnap ? getOctilinearSnap(x1, y1, mouseWorld.x, mouseWorld.y).x : mouseWorld.x;
+    const endY = useSnap ? getOctilinearSnap(x1, y1, mouseWorld.x, mouseWorld.y).y : mouseWorld.y;
+
+    p.line(x1, y1, endX, endY);
   }
   p.stroke(0);
   p.strokeWeight(1);

--- a/render/wireGeometry.js
+++ b/render/wireGeometry.js
@@ -1,6 +1,7 @@
 import { GRID_SIZE } from "../constants.js";
 import { isNearWaypoint } from "../input/mouseHandlers.js";
 import { screenToWorld } from "../state.js";
+import { getOctilinearSnap } from "./draw.js";
 
 export function initWire(renderNodes, wire, custom_waypoints, nodeMap) {
   let waypoints;
@@ -57,11 +58,29 @@ export function computeWayPoints(renderNodes, wire, nodeMap) {
   return waypoints;
 }
 
-export function setCustomWaypoints(p) {
+// Uses document.addEventListener instead of p5's keyPressed because p5 only
+// supports a single keyPressed callback per instance (already used by
+// keyboardHandlers.js for tool shortcuts). addEventListener is stackable
+// and can be cleanly removed on cleanup when wire drawing ends.
+export function setCustomWaypoints(p, startPort) {
   let waypoints = [];
   function onKeyDown(e) {
     if (e.key === " ") {
-      const { x: wx, y: wy } = screenToWorld(p.mouseX, p.mouseY);
+      const { x: rawX, y: rawY } = screenToWorld(p.mouseX, p.mouseY);
+      let wx = rawX;
+      let wy = rawY;
+
+      // Snap to octilinear angle when Shift is held.
+      // Reference point: last waypoint, or the wire's start port for the first one.
+      if (p.keyIsDown(p.SHIFT)) {
+        const prev = waypoints.length > 0
+          ? waypoints[waypoints.length - 1]
+          : startPort;
+        const snapped = getOctilinearSnap(prev.x, prev.y, rawX, rawY);
+        wx = snapped.x;
+        wy = snapped.y;
+      }
+
       if (waypoints.length !== 0) {
         const waypoint_count = waypoints.length;
         if (!isNearWaypoint(wx, wy, waypoints[waypoint_count - 1], p)) {


### PR DESCRIPTION
# Octilinear Wire Snapping

## 📝 Summary
This PR introduces **octilinear wire snapping**, allowing users to draw perfectly horizontal, vertical, or 45-degree diagonal wires by holding the `Shift` key. This significantly improves the user experience by providing more precise and aesthetically pleasing control during circuit layout.

## ✨ Key Features & Changes
* **Shift-based Angle Snapping:** Added a new `getOctilinearSnap` utility function in `render/draw.js` that calculates and restricts mouse coordinates to 0°, 45°, and 90° angles relative to a starting reference point.
* **Real-time Ghost Wire Snapping:** Integrated the snapping utility into `drawGhostWire` (`render/draw.js`), so that the temporary wire being actively drawn immediately snaps to the nearest octilinear path when the `Shift` key is held down. 
* **Custom Waypoint Support:** Extended the snapping feature to custom wire waypoints in `render/wireGeometry.js`. When a user places a custom waypoint (using the `Space` key) while holding `Shift`, the new waypoint is locked to an octilinear angle relative to the previous waypoint (or the starting port, if it's the first waypoint).

## 🛠 Technical Details
* Updated `input/mouseHandlers.js` to extract and pass the exact starting port (`startPort`) into `setCustomWaypoints`, ensuring the math for the very first snapped waypoint has the correct baseline coordinate. 
* Added documentation inside `render/wireGeometry.js` explaining the architectural decision to use `document.addEventListener` instead of p5's `keyPressed` for the custom waypoint logic. This ensures listeners are stackable and prevents conflicts with the global tool shortcuts defined in `keyboardHandlers.js`.
